### PR TITLE
LargeSet.Exists() throws an exception

### DIFF
--- a/AerospikeClient/Large/LargeSet.cs
+++ b/AerospikeClient/Large/LargeSet.cs
@@ -100,7 +100,7 @@ namespace Aerospike.Client
 		/// <param name="value">value to check</param>
 		public bool Exists(Value value)
 		{
-			int ret = (int)client.Execute(policy, key, PackageName, "exists", binName, value);
+			long ret = (long)client.Execute(policy, key, PackageName, "exists", binName, value);
 			return ret == 1;
 		}
 


### PR DESCRIPTION
The Execute call returns long instead of int and causes type cast to fail.
