### PR TITLE
Added support for Mono

### DIFF
--- a/AerospikeDemo/DemoForm.cs
+++ b/AerospikeDemo/DemoForm.cs
@@ -543,15 +543,20 @@ namespace Aerospike.Demo
         {
             // Adjust path for whether using x64/x86 or AnyCPU compile target.
             string filename = example.GetType().Name + ".cs";
-            string path = @"..\..\..\" + filename;
 
-            if (! File.Exists(path))
+            //  Look for source files up directory tree
+            string path = ".." + Path.DirectorySeparatorChar + ".." + Path.DirectorySeparatorChar;
+            int i=8;
+            do 
             {
-                path = @"..\..\" + filename;
-            }
-            return File.ReadAllText(path);
-        }
+                if (File.Exists(path+filename)) break;
+                path += ".." + Path.DirectorySeparatorChar;
+                i--;
+            } while (i > 0);
 
+            return File.ReadAllText(path+filename);
+        }
+            
         public void Run(Arguments args)
         {
             example.Run(args);


### PR DESCRIPTION
I found that the Aerospike demo didn't work with mono on OSX Yosemite. The problem was the code assumed "\" as the directory separator and a specific ordering of the directory structure. I made changes that work on OSX Yosemite and should work on Windows and Linux as well as prior versions of OSX. It would be good to test on these environments - I will when I can.

Demo seems to work fine now.

Code changes were in DemoForm.cs to TreeNode Read()

Commit comments are:

Tested on OSX/Yosemite
Needs test on earlier versions and Linux as well as Windows
Used native directory separator
Added upward search for source files