### PR TITLE
Async extensions for AsyncClient

### DIFF
--- a/AerospikeClient/AerospikeClient.csproj
+++ b/AerospikeClient/AerospikeClient.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
@@ -215,6 +215,14 @@
     <Compile Include="Async\AsyncWrite.cs" />
     <Compile Include="Async\AsyncTimeoutQueue.cs" />
     <Compile Include="Async\MaxCommandAction.cs" />
+    <Compile Include="AsyncTask\AsyncClientExtensions.cs" />
+    <Compile Include="AsyncTask\DeleteListenerAdapter.cs" />
+    <Compile Include="AsyncTask\ExistsArrayListenerAdapter.cs" />
+    <Compile Include="AsyncTask\ExistsListenerAdapter.cs" />
+    <Compile Include="AsyncTask\ListenerAdapter.cs" />
+    <Compile Include="AsyncTask\RecordArrayListenerAdapter.cs" />
+    <Compile Include="AsyncTask\RecordListenerAdapter.cs" />
+    <Compile Include="AsyncTask\WriteListenerAdapter.cs" />
     <Compile Include="Main\Bin.cs" />
     <Compile Include="Cluster\Cluster.cs" />
     <Compile Include="Cluster\Connection.cs" />

--- a/AerospikeClient/AsyncTask/AsyncClientExtensions.cs
+++ b/AerospikeClient/AsyncTask/AsyncClientExtensions.cs
@@ -1,0 +1,303 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Aerospike.Client;
+
+namespace Aerospike.Client
+{
+    /// <summary>
+    /// Async/await extensions for AsyncClient.
+    /// </summary>
+    public static class AsyncClientExtensions
+    {
+        /// <summary>
+        /// Asynchronously write record bin(s). 
+        /// <para>
+        /// The policy specifies the transaction timeout, record expiration and how the transaction is
+        /// handled when the record already exists.
+        /// </para>
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">write configuration parameters, pass in null for defaults</param>
+        /// <param name="key">unique record identifier</param>
+        /// <param name="bins">array of bin name/value pairs</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task PutAsync(this AsyncClient client, CancellationToken token, WritePolicy policy, Key key, params Bin[] bins)
+        {
+            var listener = new WriteListenerAdapter(token);
+            client.Put(policy, listener, key, bins);
+            return listener.Task;
+        }
+
+        /// <summary>
+        /// Asynchronously append bin string values to existing record bin values.
+        /// <para>
+        /// The policy specifies the transaction timeout, record expiration and how the transaction is
+        /// handled when the record already exists.
+        /// This call only works for string values. 
+        /// </para>
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">write configuration parameters, pass in null for defaults</param>
+        /// <param name="key">unique record identifier</param>
+        /// <param name="bins">array of bin name/value pairs</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task AppendAsync(this AsyncClient client, CancellationToken token, WritePolicy policy, Key key, params Bin[] bins)
+        {
+            var listener = new WriteListenerAdapter(token);
+            client.Append(policy, listener, key, bins);
+            return listener.Task;
+        }
+
+        /// <summary>
+        /// Asynchronously prepend bin string values to existing record bin values.
+        /// <para>
+        /// The policy specifies the transaction timeout, record expiration and how the transaction is
+        /// handled when the record already exists.
+        /// This call works only for string values. 
+        /// </para>
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">write configuration parameters, pass in null for defaults</param>
+        /// <param name="key">unique record identifier</param>
+        /// <param name="bins">array of bin name/value pairs</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task Prepend(this AsyncClient client, CancellationToken token, WritePolicy policy, Key key, params Bin[] bins)
+        {
+            var listener = new WriteListenerAdapter(token);
+            client.Prepend(policy, listener, key, bins);
+            return listener.Task;
+        }
+
+        /// <summary>
+        /// Asynchronously add integer bin values to existing record bin values.
+        /// <para>
+        /// The policy specifies the transaction timeout, record expiration and how the transaction is
+        /// handled when the record already exists.
+        /// This call only works for integer values. 
+        /// </para>
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">write configuration parameters, pass in null for defaults</param>
+        /// <param name="key">unique record identifier</param>
+        /// <param name="bins">array of bin name/value pairs</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task AddAsync(this AsyncClient client, CancellationToken token, WritePolicy policy, Key key, params Bin[] bins)
+        {
+            var listener = new WriteListenerAdapter(token);
+            client.Add(policy, listener, key, bins);
+            return listener.Task;
+        }
+
+        /// <summary>
+        /// Asynchronously delete record for specified key.
+        /// <para>
+        /// The policy specifies the transaction timeout.
+        /// </para>
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">delete configuration parameters, pass in null for defaults</param>
+        /// <param name="key">unique record identifier</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task<bool> DeleteAsync(this AsyncClient client, CancellationToken token, WritePolicy policy, Key key)
+        {
+            var listener = new DeleteListenerAdapter(token);
+            client.Delete(policy, listener, key);
+            return listener.Task;
+        }
+
+
+        /// <summary>
+        /// Asynchronously create record if it does not already exist.  If the record exists, the record's 
+        /// time to expiration will be reset to the policy's expiration.
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">write configuration parameters, pass in null for defaults</param>
+        /// <param name="key">unique record identifier</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task TouchAsync(this AsyncClient client, CancellationToken token, WritePolicy policy, Key key)
+        {
+            var listener = new WriteListenerAdapter(token);
+            client.Touch(policy, listener, key);
+            return listener.Task;
+        }
+
+        /// <summary>
+        /// Asynchronously determine if a record key exists.
+        /// <para>
+        /// The policy can be used to specify timeouts.
+        /// </para>
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">generic configuration parameters, pass in null for defaults</param>
+        /// <param name="key">unique record identifier</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task<bool> ExistsAsync(this AsyncClient client, CancellationToken token, Policy policy, Key key)
+        {
+            var listener = new ExistsListenerAdapter(token);
+            client.Exists(policy, listener, key);
+            return listener.Task;
+        }
+
+
+        /// <summary>
+        /// Asynchronously check if multiple record keys exist in one batch call.
+        /// <para>
+        /// The policy can be used to specify timeouts.
+        /// </para>
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">generic configuration parameters, pass in null for defaults</param>
+        /// <param name="keys">array of unique record identifiers</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task<bool[]> ExistsAsync(this AsyncClient client, CancellationToken token, Policy policy, Key[] keys)
+        {
+            var listener = new ExistsArrayListenerAdapter(token);
+            client.Exists(policy, listener, keys);
+            return listener.Task;
+        }
+
+
+        /// <summary>
+        /// Asynchronously read entire record for specified key.
+        /// <para>
+        /// The policy can be used to specify timeouts.
+        /// </para>
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">generic configuration parameters, pass in null for defaults</param>
+        /// <param name="key">unique record identifier</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task<Record> GetAsync(this AsyncClient client, CancellationToken token, Policy policy, Key key)
+        {
+            var listener = new RecordListenerAdapter(token);
+            client.Get(policy, listener, key);
+            return listener.Task;
+        }
+
+        /// <summary>
+        /// Asynchronously read record generation and expiration only for specified key.  Bins are not read.
+        /// <para>
+        /// The policy can be used to specify timeouts.
+        /// </para>
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">generic configuration parameters, pass in null for defaults</param>
+        /// <param name="key">unique record identifier</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task<Record> GetHeaderAsync(this AsyncClient client, CancellationToken token, Policy policy, Key key)
+        {
+            var listener = new RecordListenerAdapter(token);
+            client.GetHeader(policy, listener, key);
+            return listener.Task;
+        }
+
+        /// <summary>
+        /// Asynchronously read record header and bins for specified key.
+        /// <para>
+        /// The policy can be used to specify timeouts.
+        /// </para>
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">generic configuration parameters, pass in null for defaults</param>
+        /// <param name="key">unique record identifier</param>
+        /// <param name="binNames">bins to retrieve</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task<Record> GetAsync(this AsyncClient client, CancellationToken token, Policy policy, Key key, params string[] binNames)
+        {
+            var listener = new RecordListenerAdapter(token);
+            client.Get(policy, listener, key, binNames);
+            return listener.Task;
+        }
+
+        /// <summary>
+        /// Asynchronously read multiple records for specified keys in one batch call.
+        /// <para>
+        /// If a key is not found, the record will be null.
+        /// The policy can be used to specify timeouts.
+        /// </para>
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">generic configuration parameters, pass in null for defaults</param>
+        /// <param name="keys">array of unique record identifiers</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task<Record[]> GetAsync(this AsyncClient client, CancellationToken token, Policy policy, Key[] keys)
+        {
+            var listener = new RecordArrayListenerAdapter(token);
+            client.Get(policy, listener, keys);
+            return listener.Task;
+        }
+
+        /// <summary>
+        /// Asynchronously read multiple record header data for specified keys in one batch call.
+        /// <para>
+        /// If a key is not found, the record will be null.
+        /// The policy can be used to specify timeouts.
+        /// </para>
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">generic configuration parameters, pass in null for defaults</param>
+        /// <param name="keys">array of unique record identifiers</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task<Record[]> GetHeaderAsync(this AsyncClient client, CancellationToken token, Policy policy, Key[] keys)
+        {
+            var listener = new RecordArrayListenerAdapter(token);
+            client.GetHeader(policy, listener, keys);
+            return listener.Task;
+        }
+
+        /// <summary>
+        /// Asynchronously read multiple record headers and bins for specified keys in one batch call.
+        /// <para>
+        /// If a key is not found, the record will be null.
+        /// The policy can be used to specify timeouts.
+        /// </para>
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">generic configuration parameters, pass in null for defaults</param>
+        /// <param name="keys">array of unique record identifiers</param>
+        /// <param name="binNames">array of bins to retrieve</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task<Record[]> GetAsync(this AsyncClient client, CancellationToken token, Policy policy, Key[] keys, params string[] binNames)
+        {
+            var listener = new RecordArrayListenerAdapter(token);
+            client.Get(policy, listener, keys, binNames);
+            return listener.Task;
+        }
+
+        /// <summary>
+        /// Asynchronously perform multiple read/write operations on a single key in one batch call.
+        /// An example would be to add an integer value to an existing record and then
+        /// read the result, all in one database call.
+        /// </summary>
+        /// <param name="client">AsyncClient istance</param>
+        /// <param name="token">cancellation token</param>
+        /// <param name="policy">write configuration parameters, pass in null for defaults</param>
+        /// <param name="key">unique record identifier</param>
+        /// <param name="operations">database operations to perform</param>
+        /// <exception cref="AerospikeException">if queue is full</exception>
+        public static System.Threading.Tasks.Task<Record> OperateAsync(this AsyncClient client, CancellationToken token, WritePolicy policy, Key key, params Operation[] operations)
+        {
+            var listener = new RecordListenerAdapter(token);
+            client.Operate(policy, listener, key, operations);
+            return listener.Task;
+        }
+    }
+}

--- a/AerospikeClient/AsyncTask/DeleteListenerAdapter.cs
+++ b/AerospikeClient/AsyncTask/DeleteListenerAdapter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Aerospike.Client;
+
+namespace Aerospike.Client
+{
+    internal sealed class DeleteListenerAdapter : ListenerAdapter<bool>, DeleteListener
+    {
+        public DeleteListenerAdapter(CancellationToken token)
+            : base(token)
+        {
+
+        }
+
+        public void OnSuccess(Key key, bool existed)
+        {
+            SetResult(existed);
+        }
+    }
+
+}

--- a/AerospikeClient/AsyncTask/ExistsArrayListenerAdapter.cs
+++ b/AerospikeClient/AsyncTask/ExistsArrayListenerAdapter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Aerospike.Client;
+
+namespace Aerospike.Client
+{
+    internal sealed class ExistsArrayListenerAdapter : ListenerAdapter<bool[]>, ExistsArrayListener
+    {
+        public ExistsArrayListenerAdapter(CancellationToken token)
+            : base(token)
+        {
+
+        }
+
+        public void OnSuccess(Key[] keys, bool[] exists)
+        {
+            SetResult(exists);
+        }
+    }
+}

--- a/AerospikeClient/AsyncTask/ExistsListenerAdapter.cs
+++ b/AerospikeClient/AsyncTask/ExistsListenerAdapter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Aerospike.Client;
+
+namespace Aerospike.Client
+{
+    internal sealed class ExistsListenerAdapter : ListenerAdapter<bool>, ExistsListener
+    {
+        public ExistsListenerAdapter(CancellationToken token)
+            : base(token)
+        {
+
+        }
+
+        public void OnSuccess(Key key, bool exists)
+        {
+            SetResult(exists);
+        }
+
+    }
+}

--- a/AerospikeClient/AsyncTask/ListenerAdapter.cs
+++ b/AerospikeClient/AsyncTask/ListenerAdapter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Aerospike.Client;
+
+namespace Aerospike.Client
+{
+    internal abstract class ListenerAdapter<T>
+    {
+        public ListenerAdapter(CancellationToken token)
+        {
+            token.Register(() => tcs.TrySetCanceled(), useSynchronizationContext: false);
+        }
+
+        protected void SetResult(T result)
+        {
+            tcs.TrySetResult(result);
+        }
+
+        public void OnFailure(AerospikeException exception)
+        {
+            tcs.SetException(exception);
+        }
+
+        public System.Threading.Tasks.Task<T> Task { get { return tcs.Task; } }
+
+        private readonly TaskCompletionSource<T> tcs = new TaskCompletionSource<T>();
+    }
+}

--- a/AerospikeClient/AsyncTask/RecordArrayListenerAdapter.cs
+++ b/AerospikeClient/AsyncTask/RecordArrayListenerAdapter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Aerospike.Client;
+
+namespace Aerospike.Client
+{
+    internal sealed class RecordArrayListenerAdapter : ListenerAdapter<Record[]>, RecordArrayListener
+    {
+        public RecordArrayListenerAdapter(CancellationToken token)
+            : base(token)
+        {
+
+        }
+
+        public void OnSuccess(Key[] keys, Record[] records)
+        {
+            SetResult(records);
+        }
+    }
+}

--- a/AerospikeClient/AsyncTask/RecordListenerAdapter.cs
+++ b/AerospikeClient/AsyncTask/RecordListenerAdapter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Aerospike.Client;
+
+namespace Aerospike.Client
+{
+    internal sealed class RecordListenerAdapter : ListenerAdapter<Record>, RecordListener
+    {
+        public RecordListenerAdapter(CancellationToken token)
+            : base(token)
+        {
+
+        }
+
+        public void OnSuccess(Key key, Record record)
+        {
+            SetResult(record);
+        }
+    }
+}

--- a/AerospikeClient/AsyncTask/WriteListenerAdapter.cs
+++ b/AerospikeClient/AsyncTask/WriteListenerAdapter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Aerospike.Client;
+
+namespace Aerospike.Client
+{
+    internal sealed class WriteListenerAdapter : ListenerAdapter<Key>, WriteListener
+    {
+        public WriteListenerAdapter(CancellationToken token)
+            : base(token)
+        {
+
+        }
+
+        public void OnSuccess(Key key)
+        {
+            SetResult(key);
+        }
+    }
+}


### PR DESCRIPTION
It is quite hard to use AsyncClient, especially when I have to integrate it with client code based on the Task-based Asynchronous Pattern (TAP). 
Added xxxAsync overloads to most of the calls, except ones that use sequence listeners.

Example
```
        public async Task<string> Example(AsyncClient asyncClient, CancellationToken token)
        {
            string ns = "test";
            string set = "asyncTest";
            Key key = new Key(ns, set, 123);

            await asyncClient.PutAsync(token, null, key, new Bin("x", "xvalue"));
            Record r = await asyncClient.GetAsync(token, null, key);

            return (string)r.GetValue("x");
        }
```