### PR TITLE
Throw SocketException instead of TimeoutException

### DIFF
--- a/AerospikeClient/Command/SyncCommand.cs
+++ b/AerospikeClient/Command/SyncCommand.cs
@@ -90,6 +90,7 @@ namespace Aerospike.Client
 						{
 							Log.Debug("Node " + node + ": " + Util.GetErrorMessage(ioe));
 						}
+                        throw;
 					}
 					catch (Exception)
 					{


### PR DESCRIPTION
We are seeing issues when the Aerospike server is down the exception I get back is TimeoutException but it should be a SocketException?