### PR TITLE
Fixes Race condition in ListenerAdapter<T>.OnFailure, System.InvalidOperationException

### DIFF
--- a/AerospikeClient/AsyncTask/ListenerAdapter.cs
+++ b/AerospikeClient/AsyncTask/ListenerAdapter.cs
@@ -39,7 +39,7 @@ namespace Aerospike.Client
 
 		public void OnFailure(AerospikeException exception)
 		{
-			tcs.SetException(exception);
+			tcs.TrySetException(exception);
 			ctr.Dispose();
 		}
 


### PR DESCRIPTION
Fixes https://github.com/aerospike/aerospike-client-csharp/issues/20

Exception: System.InvalidOperationException

Message: An attempt was made to transition a task to a final state when it had already completed.

StackTrace: at System.Threading.Tasks.TaskCompletionSource1.SetException(Exception exception) at Aerospike.Client.ListenerAdapter1.OnFailure(AerospikeException exception)
at Aerospike.Client.AsyncRead.OnFailure(AerospikeException e)
at Aerospike.Client.AsyncCommand.FailOnApplicationError(AerospikeException ae)
at Aerospike.Client.AsyncCommand.SocketHandler(Object sender, SocketAsyncEventArgs args)
at System.Net.Sockets.SocketAsyncEventArgs.OnCompleted(SocketAsyncEventArgs e)
at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
at System.Net.Sockets.SocketAsyncEventArgs.FinishOperationSuccess(SocketError socketError, Int32 bytesTransferred, SocketFlags flags)
at System.Net.Sockets.SocketAsyncEventArgs.CompletionPortCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped)
at System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* pOVERLAP)