### PR TITLE
Make "blocking" async commands non-blocking

### DIFF
--- a/Core/AerospikeClient/Async/AsyncCommandDelayingQueue.cs
+++ b/Core/AerospikeClient/Async/AsyncCommandDelayingQueue.cs
@@ -1,0 +1,134 @@
+/* 
+ * Copyright 2012-2017 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+using System.Threading;
+
+namespace Aerospike.Client
+{
+	internal sealed class AsyncCommandDelayingQueue : AsyncCommandQueueBase
+	{
+		private readonly ConcurrentQueue<SocketAsyncEventArgs> _argsQueue = new ConcurrentQueue<SocketAsyncEventArgs>();
+		private readonly ConcurrentQueue<AsyncCommand> _commandQueue = new ConcurrentQueue<AsyncCommand>();
+		private readonly WaitCallback _schedulingJobCallback;
+		private volatile int _jobScheduled;
+
+		public AsyncCommandDelayingQueue()
+		{
+			_schedulingJobCallback = new WaitCallback(ExclusiveScheduleCommands);
+		}
+
+		// Releases a SocketEventArgs object to the pool.
+		public override void ReleaseArgs(SocketAsyncEventArgs e)
+		{
+			AsyncCommand command;
+
+			if (_commandQueue.TryDequeue(out command))
+			{
+				command.ExecuteAsync(e);
+			}
+			else
+			{
+				_argsQueue.Enqueue(e);
+				TriggerCommandScheduling();
+			}
+		}
+
+		// Schedules a command for later execution.
+		public override bool ScheduleCommand(AsyncCommand command)
+		{
+			SocketAsyncEventArgs e;
+
+			// Try to dequeue one SocketAsyncEventArgs object from the queue and execute it.
+			if (_argsQueue.TryDequeue(out e))
+			{
+				// If there are no awaiting command, the current command can be executed immediately.
+				if (_commandQueue.IsEmpty) // NB: We could make the choice to always execute the command synchronously in this case. Might be better for performance.
+				{
+					command.ExecuteInline(e);
+					return true;
+				}
+				else
+				{
+					_argsQueue.Enqueue(e);
+				}
+			}
+			else
+			{
+				// In blocking mode, the command can be queued for later execution.
+				_commandQueue.Enqueue(command);
+			}
+
+			TriggerCommandScheduling();
+			return true;
+		}
+
+		// Schedule exactly once the job that will execute queued commands.
+		private void TriggerCommandScheduling()
+		{
+			if (Interlocked.CompareExchange(ref _jobScheduled, 1, 0) == 0)
+			{
+#if NETCORE && !NETSTANDARD2_0
+				ThreadPool.QueueUserWorkItem(_schedulingJobCallback, null);
+#else
+				ThreadPool.UnsafeQueueUserWorkItem(_schedulingJobCallback, null);
+#endif
+			}
+		}
+
+		// Schedule as many commands as possible.
+		private void ExclusiveScheduleCommands(object state)
+		{
+			do
+			{
+				bool lockTaken = false;
+				try
+				{
+					// Lock on _commandQueue for exclusive execution of the job.
+					Monitor.TryEnter(_commandQueue, ref lockTaken); // If we can't enter the lock, it means another instance of the job is already doing the work.
+					if (!lockTaken) return;
+
+					_jobScheduled = 1; // Volatile Write. At this point, the job cannot be rescheduled.
+
+					// Try scheduling as many commands as possible.
+					SocketAsyncEventArgs e;
+					while (!_commandQueue.IsEmpty && _argsQueue.TryDequeue(out e))
+					{
+						AsyncCommand dequeuedCommand;
+						if (_commandQueue.TryDequeue(out dequeuedCommand))
+						{
+							dequeuedCommand.ExecuteAsync(e);
+						}
+						else
+						{
+							_argsQueue.Enqueue(e);
+						}
+					}
+				}
+				finally
+				{
+					if (lockTaken)
+					{
+						_jobScheduled = 0; // Volatile Write. At this point, the job can be rescheduled.
+						Monitor.Exit(_commandQueue);
+					}
+				}
+			}
+			while (!(_commandQueue.IsEmpty || _argsQueue.IsEmpty)); // Re-execute the job as long as both queues are non-empty
+		}
+	}
+}

--- a/Core/AerospikeClient/Async/AsyncCommandQueueBase.cs
+++ b/Core/AerospikeClient/Async/AsyncCommandQueueBase.cs
@@ -14,27 +14,16 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+using System.Net.Sockets;
+
 namespace Aerospike.Client
 {
-	/// <summary>
-	/// How to handle cases when the asynchronous maximum number of concurrent database commands have been exceeded.
-	/// </summary>
-	public enum MaxCommandAction
+	internal abstract class AsyncCommandQueueBase
 	{
-		/// <summary>
-		/// Reject database command.
-		/// </summary>
-		REJECT,
+		// Releases a SocketEventArgs object to the pool.
+		public abstract void ReleaseArgs(SocketAsyncEventArgs e);
 
-		/// <summary>
-		/// Block until a previous command completes. 
-		/// </summary>
-		BLOCK,
-
-		/// <summary>
-		/// Delay until a previous command completes.
-		/// </summary>
-		/// <remarks>This is the asynchronous equivalent of <see cref="BLOCK"/>.</remarks>
-		DELAY,
+		// Schedules a command for later execution, and returns a boolean indicating if the command has been executed or is actually going be executed.
+		public abstract bool ScheduleCommand(AsyncCommand command);
 	}
 }

--- a/Core/AerospikeClient/Async/AsyncCommandRejectingQueue.cs
+++ b/Core/AerospikeClient/Async/AsyncCommandRejectingQueue.cs
@@ -1,0 +1,51 @@
+/* 
+ * Copyright 2012-2017 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+
+namespace Aerospike.Client
+{
+	internal sealed class AsyncCommandRejectingQueue : AsyncCommandQueueBase
+	{
+		private readonly ConcurrentQueue<SocketAsyncEventArgs> _argsQueue = new ConcurrentQueue<SocketAsyncEventArgs>();
+
+		public AsyncCommandRejectingQueue() { }
+
+		// Releases a SocketEventArgs object to the pool.
+		public override void ReleaseArgs(SocketAsyncEventArgs e)
+		{
+			_argsQueue.Enqueue(e);
+		}
+
+		// Schedules a command for later execution.
+		public override bool ScheduleCommand(AsyncCommand command)
+		{
+			SocketAsyncEventArgs e;
+			
+			// Try to dequeue one SocketAsyncEventArgs object from the queue and execute the command.
+			if (_argsQueue.TryDequeue(out e))
+			{
+				command.ExecuteInline(e);
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
+	}
+}

--- a/Framework/AerospikeClient/AerospikeClient.csproj
+++ b/Framework/AerospikeClient/AerospikeClient.csproj
@@ -218,6 +218,18 @@
     <Compile Include="..\..\Core\AerospikeClient\Async\AsyncCommand.cs">
       <Link>Async\AsyncCommand.cs</Link>
     </Compile>
+    <Compile Include="..\..\Core\AerospikeClient\Async\AsyncCommandBlockingQueue.cs">
+      <Link>Async\AsyncCommandBlockingQueue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Core\AerospikeClient\Async\AsyncCommandDelayingQueue.cs">
+      <Link>Async\AsyncCommandDelayingQueue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Core\AerospikeClient\Async\AsyncCommandQueueBase.cs">
+      <Link>Async\AsyncCommandQueueBase.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Core\AerospikeClient\Async\AsyncCommandRejectingQueue.cs">
+      <Link>Async\AsyncCommandRejectingQueue.cs</Link>
+    </Compile>
     <Compile Include="..\..\Core\AerospikeClient\Async\AsyncConnection.cs">
       <Link>Async\AsyncConnection.cs</Link>
     </Compile>


### PR DESCRIPTION
Hello,

I'd like to propose you this patch, that introduces a new internal class named `AsyncCommandQueue`, whose goal is to replace the previous usage of `BlockingCollection` in `AsyncCluster`.

The goal of this modification is to reduce thread contention, and diminish ThreadPool starvation in some extreme cases, when using `AsyncClient`.

### Background

We have been using the Aerospike C# client for almost one year in our ASP.NET/IIS application. Since a few months, when we were scaling up Aerospike, we began to occasionally notice a surge of HTTP 503 errors and CPU spikes on some of our servers (depending on their hardware configuration), mostly happening at random, and never more than twice a day. (When happening, it was always right after an IIS worker process recycle, but that was a red herring)

We were lucky enough  that some of our SRE coworkers were able to capture a few dumps of the processes that went using 100% CPU. That helped us pinpoint the root cause of those CPU spikes, and attribute it to the use of `BlockingCollection`, which internally relies on `SemaphoreSlim`.

Since we are using the `AsyncClient` in fully asynchronous mode, blocking threads did not seem to be a valid option anyway, so I proposed that we try replacing the `BlockingCollection` by something that would offer a similar behavior in a fully non-blocking way.

We deployed a patched version of the driver on one of our most affected servers, and compared the behavior with another server. The result was that the patched server displayed absolutely no abnormal CPU spike during the period, while the unpatched server did display them as before.

Here are some screeshots of our monitoring tool for the two servers, taken at the beginning of november:

Patched server:
![patchedserver](https://user-images.githubusercontent.com/8518235/33178871-d6154152-d067-11e7-9077-23b594504c62.png)

Unpatched server:
![unpatchedserver](https://user-images.githubusercontent.com/8518235/33178874-d93bf858-d067-11e7-8677-5ed44ad94333.png)

Configuration for the two servers: 2x Xeon E5-2650 v4 @ 2.20 GHz (48 Logical Cores) running in 64 bit mode, 16 GB RAM

### Caveat

While the patch did work perfectly for our use cases, I noticed a bug in the `AerospikeDemo` application: It seems the asynchronous operations are not awaited in the asynchronous benchmark code. This causes the connection to the cluster to be closed before most commands are even able to reach the cluster, and the benchmark fails to complete correctly because of that.
