### PR TITLE
Fix KeyNotFoundException in SetAddress()

### DIFF
--- a/Framework/AerospikeClient/Cluster/NodeValidator.cs
+++ b/Framework/AerospikeClient/Cluster/NodeValidator.cs
@@ -301,9 +301,7 @@ namespace Aerospike.Client
 
 		private void SetAddress(Cluster cluster, Dictionary<string, string> map, string addressCommand, string tlsName)
 		{
-			string result = map[addressCommand];
-
-			if (result == null || result.Length == 0)
+			if (!map.TryGetValue(addressCommand, out var result) || result == null || result.Length == 0)
 			{
 				// Server does not support service level call (service-clear-std, ...).
 				// Load balancer detection is not possible.


### PR DESCRIPTION
It looks like the intention here was to check if `addressCommand` is present in the map. This fails for us with `KeyNotFoundException` when command is `service-clear-std`.