### PR TITLE
Use List instead of Array.

### DIFF
--- a/Framework/AerospikeClient/Async/AsyncMultiExecutor.cs
+++ b/Framework/AerospikeClient/Async/AsyncMultiExecutor.cs
@@ -14,6 +14,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace Aerospike.Client
@@ -56,22 +60,21 @@ namespace Aerospike.Client
 		public void ExecuteBatchRetry(AsyncMultiCommand[] cmds, AsyncMultiCommand orig)
 		{
 			// Create new commands array.
-			AsyncMultiCommand[] target = new AsyncMultiCommand[commands.Length + cmds.Length - 1];
-			int count = 0;
+			List<AsyncMultiCommand> target = new List<AsyncMultiCommand>();
 
 			foreach (AsyncMultiCommand cmd in commands)
 			{
 				if (cmd != orig)
 				{
-					target[count++] = cmd;
+					target.Add(cmd);
 				}
 			}
 
 			foreach (AsyncMultiCommand cmd in cmds)
 			{
-				target[count++] = cmd;
+				target.Add(cmd);
 			}
-			commands = target;
+			commands = target.ToArray();
 
 			// Batch executors always execute all commands at once.
 			// Execute all new commands.


### PR DESCRIPTION
Sometimes, when `ExecuteBatchRetry` is called, `orig` is not present in either `commands` or `cmds`. We had two options:

1. Check to see if either array contains the object and then create the array with the correct size (expensive)
2. Use a list, and then convert it to an array when finished (less expensive).,

This prevents an IndexOutOfRangeException Seen in issue #50 .

This has been tested locally in my application, with forced timeouts by using clumsy 0.2 for Windows. With these changes, we're able to achieve all iterations in our async batch read.