### PR TITLE
Add low level functions for strongly typed unpacking of values from list/map bins

### DIFF
--- a/Core/AerospikeTest/AerospikeTest.csproj
+++ b/Core/AerospikeTest/AerospikeTest.csproj
@@ -50,6 +50,7 @@
     <Compile Include="..\..\Framework\AerospikeTest\Sync\Basic\TestAppend.cs" Link="Sync\TestAppend.cs" />
     <Compile Include="..\..\Framework\AerospikeTest\Sync\Basic\TestBatch.cs" Link="Sync\TestBatch.cs" />
     <Compile Include="..\..\Framework\AerospikeTest\Sync\Basic\TestBitExp.cs" Link="Sync\TestBitExp.cs" />
+    <Compile Include="..\..\Framework\AerospikeTest\Sync\Basic\TestCustomParser.cs" Link="Sync\TestCustomParser.cs" />
     <Compile Include="..\..\Framework\AerospikeTest\Sync\Basic\TestDeleteBin.cs" Link="Sync\TestDeleteBin.cs" />
     <Compile Include="..\..\Framework\AerospikeTest\Sync\Basic\TestExpire.cs" Link="Sync\TestExpire.cs" />
     <Compile Include="..\..\Framework\AerospikeTest\Sync\Basic\TestExpOperation.cs" Link="Sync\TestExpOperation.cs" />

--- a/Framework/AerospikeClient/Util/Unpacker.cs
+++ b/Framework/AerospikeClient/Util/Unpacker.cs
@@ -494,5 +494,649 @@ namespace Aerospike.Client
 				}
 			}
 		}
+
+		/// <summary>
+		/// Extract an integer value from the buffer. The integer value is always returned as long
+		/// even if the actual type is unsigned.
+		/// </summary>
+		/// <returns>extracted value (can be null)</returns>
+		public long? UnpackInteger()
+		{
+			int type = buffer[offset++];
+
+			switch (type)
+			{
+				case 0xc0: // nil
+				{
+					return null;
+				}
+
+				case 0xd0: // signed 8 bit integer
+				{
+					return (long)(sbyte)(buffer[offset++]);
+				}
+				
+				case 0xcc: // unsigned 8 bit integer
+				{
+					return (long)(buffer[offset++]);
+				}
+
+				case 0xd1: // signed 16 bit integer
+				{
+					int val = ByteUtil.BytesToShort(buffer, offset);
+					offset += 2;
+					return (long)(short)val;
+				}
+
+				case 0xcd: // unsigned 16 bit integer
+				{
+					int val = ByteUtil.BytesToShort(buffer, offset);
+					offset += 2;
+					return (long)val;
+				}
+
+				case 0xd2: // signed 32 bit integer
+				{
+					int val = ByteUtil.BytesToInt(buffer, offset);
+					offset += 4;
+					return (long)val;
+				}
+
+				case 0xce: // unsigned 32 bit integer
+				{
+					uint val = ByteUtil.BytesToUInt(buffer, offset);
+					offset += 4;
+					return (long)val;
+				}
+
+				case 0xd3: // signed 64 bit integer
+				{
+					long val = ByteUtil.BytesToLong(buffer, offset);
+					offset += 8;
+					return val;
+				}
+
+				case 0xcf: // unsigned 64 bit integer
+				{
+					// The contract is to always return long.  
+					// The caller can always cast back to ulong.
+					long val = ByteUtil.BytesToLong(buffer, offset);
+					offset += 8;
+					return val;
+				}
+
+				default:
+					if (type < 0x80) // 8 bit combined unsigned integer
+					{
+						return type;
+					}
+
+					if (type >= 0xe0) // 8 bit combined signed integer
+					{
+						return (type - 0xe0 - 32);
+					}
+
+					throw new IOException("Unknown unpack type: " + type);
+			}
+		}
+
+		/// <summary>
+		/// Extract a boolean value from the buffer.
+		/// </summary>
+		/// <returns>extracted value (can be null)</returns>
+		public bool? UnpackBool()
+		{
+			int type = buffer[offset++];
+
+			switch (type)
+			{
+				case 0xc0: // nil
+				{
+					return null;
+				}
+
+				case 0xc3: // boolean true
+				{
+					return true;
+				}
+
+				case 0xc2: // boolean false
+				{
+					return false;
+				}
+
+				default:
+					throw new IOException("Unknown unpack type: " + type);
+			}
+		}
+
+		/// <summary>
+		/// Extract a float value from the buffer.
+		/// </summary>
+		/// <returns>extracted value (can be null)</returns>
+		public float? UnpackFloat()
+		{
+			int type = buffer[offset++];
+
+			switch (type)
+			{
+				case 0xc0: // nil
+					{
+						return null;
+					}
+
+				case 0xca: // float
+					{
+						float val = ByteUtil.BytesToFloat(buffer, offset);
+						offset += 4;
+						return val;
+					}
+
+				default:
+					throw new IOException("Unknown unpack type: " + type);
+			}
+		}
+
+		/// <summary>
+		/// Extract a double value from the buffer.
+		/// </summary>
+		/// <returns>extracted value (can be null)</returns>
+		public double? UnpackDouble()
+		{
+			int type = buffer[offset++];
+
+			switch (type)
+			{
+				case 0xc0: // nil
+				{
+					return null;
+				}
+
+				case 0xcb: // double
+				{
+					double val = ByteUtil.BytesToDouble(buffer, offset);
+					offset += 8;
+					return val;
+				}
+
+				default:
+					throw new IOException("Unknown unpack type: " + type);
+			}
+		}
+
+		/// <summary>
+		/// Extract a string value.
+		/// </summary>
+		/// <returns>extracted value (can be null)</returns>
+		public string UnpackString()
+		{
+			int type = buffer[offset++];
+
+			switch (type)
+			{
+				case 0xc0: // nil
+				{
+					return null;
+				}
+
+				case 0xc4:
+				case 0xd9: // string raw bytes with 8 bit header
+				{
+					int count = buffer[offset++];
+					return UnpackBlobString(count);
+				}
+
+				case 0xc5:
+				case 0xda: // raw bytes with 16 bit header
+				{
+					int count = ByteUtil.BytesToShort(buffer, offset);
+					offset += 2;
+					return UnpackBlobString(count);
+				}
+
+				case 0xc6:
+				case 0xdb: // raw bytes with 32 bit header
+				{
+					// Array length is restricted to positive int values (0 - int.MAX_VALUE).
+					int count = ByteUtil.BytesToInt(buffer, offset);
+					offset += 4;
+					return UnpackBlobString(count);
+				}
+
+				default:
+				{
+					if ((type & 0xe0) == 0xa0) // raw bytes with 8 bit combined header
+					{
+						return UnpackBlobString(type & 0x1f);
+					}
+
+					throw new IOException("Unknown unpack type: " + type);
+				}
+			}
+		}
+
+		private string UnpackBlobString(int count)
+		{
+			int type = buffer[offset++];
+			--count;
+			if (type != ParticleType.STRING)
+			{
+				throw new IOException("Unexpected blob type: " + type);
+			}
+
+			var value = ByteUtil.Utf8ToString(buffer, offset, count);
+			offset += count;
+			return value;
+		}
+
+		/// <summary>
+		/// Get the number of elements in a map.
+		/// </summary>
+		/// <returns>number of elements in the map</returns>
+		public int UnpackMapItemCount(out MapOrder order)
+		{
+			order = MapOrder.UNORDERED;
+
+			if (length <= 0)
+			{
+				return 0;
+			}
+
+			int type = buffer[offset++];
+			int count;
+
+			if ((type & 0xf0) == 0x80)
+			{
+				count = type & 0x0f;
+			}
+			else if (type == 0xde)
+			{
+				count = ByteUtil.BytesToShort(buffer, offset);
+				offset += 2;
+			}
+			else if (type == 0xdf)
+			{
+				count = ByteUtil.BytesToInt(buffer, offset);
+				offset += 4;
+			}
+			else
+			{
+				throw new IOException("Unexpected pack type: " + type);
+			}
+
+			// Check for extension that the server uses.
+			if (count > 0 && buffer[offset] == 0xc7)
+			{
+				int extensionType = buffer[offset + 1];
+
+				if (extensionType == 0)
+				{
+					order = (MapOrder)buffer[offset + 2];
+					offset += 3;
+					SkipObject();
+					--count;
+				}
+			}
+
+			return count;
+		}
+
+		/// <summary>
+		/// Get the number of elements in a list.
+		/// </summary>
+		/// <returns>number of elements in the list</returns>
+		public int UnpackListItemCount()
+		{
+			if (length <= 0)
+			{
+				return 0;
+			}
+		    
+			int type = buffer[offset++];
+			int count;
+
+			if ((type & 0xf0) == 0x90)
+			{
+				count = type & 0x0f;
+			}
+			else if (type == 0xdc)
+			{
+				count = ByteUtil.BytesToShort(buffer, offset);
+				offset += 2;
+			}
+			else if (type == 0xdd)
+			{
+				count = ByteUtil.BytesToInt(buffer, offset);
+				offset += 4;
+			}
+			else
+			{
+				throw new IOException("Unexpected pack type: " + type);
+			}
+
+			return SkipTypeExtensions(count);
+		}
+
+
+		/// <summary>
+		/// Advance through the buffer to skip over the next objects regardless of their type.
+		/// </summary>
+		public void SkipObjects(int count)
+		{
+			while (count-- > 0)
+			{
+				SkipObject();
+			}
+		}
+
+		/// <summary>
+		/// Advance through the buffer to skip over the next object regardless of that object's type.
+		/// </summary>
+		public void SkipObject()
+		{
+			int type = buffer[offset++];
+
+			switch (type)
+			{
+				case 0xc0: // nil
+				{
+					return;
+				}
+
+				case 0xc3: // boolean true
+				{
+					return;
+				}
+
+				case 0xc2: // boolean false
+				{
+					return;
+				}
+
+				case 0xca: // float
+				{
+					offset += 4;
+					return;
+				}
+
+				case 0xcb: // double
+				{
+					offset += 8;
+					return;
+				}
+
+				case 0xd0: // signed 8 bit integer
+				{
+					offset += 1;
+					return;
+				}
+
+				case 0xcc: // unsigned 8 bit integer
+				{
+					offset += 1;
+					return;
+				}
+
+				case 0xd1: // signed 16 bit integer
+				{
+					offset += 2;
+					return;
+				}
+
+				case 0xcd: // unsigned 16 bit integer
+				{
+					offset += 2;
+					return;
+				}
+
+				case 0xd2: // signed 32 bit integer
+				{
+					offset += 4;
+					return;
+				}
+
+				case 0xce: // unsigned 32 bit integer
+				{
+					offset += 4;
+					return;
+				}
+
+				case 0xd3: // signed 64 bit integer
+				{
+					offset += 8;
+					return;
+				}
+
+				case 0xcf: // unsigned 64 bit integer
+				{
+					offset += 8;
+					return;
+				}
+
+				case 0xc4:
+				case 0xd9: // string raw bytes with 8 bit header
+				{
+					int count = buffer[offset];
+					offset += 1 + count;
+					return;
+				}
+
+				case 0xc5:
+				case 0xda: // raw bytes with 16 bit header
+				{
+					int count = ByteUtil.BytesToShort(buffer, offset);
+					offset += 2 + count;
+					return;
+				}
+
+				case 0xc6:
+				case 0xdb: // raw bytes with 32 bit header
+				{
+					int count = ByteUtil.BytesToInt(buffer, offset);
+					offset += 4 + count;
+					return;
+				}
+
+				case 0xdc: // list with 16 bit header
+				{
+					int count = ByteUtil.BytesToShort(buffer, offset);
+					offset += 2;
+					SkipList(count);
+					return;
+				}
+
+				case 0xdd: // list with 32 bit header
+				{
+					int count = ByteUtil.BytesToInt(buffer, offset);
+					offset += 4;
+					SkipList(count);
+					return;
+				}
+
+				case 0xde: // map with 16 bit header
+				{
+					int count = ByteUtil.BytesToShort(buffer, offset);
+					offset += 2;
+					SkipMap(count);
+					return;
+				}
+
+				case 0xdf: // map with 32 bit header
+				{
+					int count = ByteUtil.BytesToInt(buffer, offset);
+					offset += 4;
+					SkipMap(count);
+					return;
+				}
+
+				case 0xd4: // Skip over type extension with 1 byte
+				{
+					offset += 1 + 1;
+					return;
+				}
+
+				case 0xd5: // Skip over type extension with 2 bytes
+				{
+					offset += 1 + 2;
+					return;
+				}
+
+				case 0xd6: // Skip over type extension with 4 bytes
+				{
+					offset += 1 + 4;
+					return;
+				}
+
+				case 0xd7: // Skip over type extension with 8 bytes
+				{
+					offset += 1 + 8;
+					return;
+				}
+
+				case 0xd8: // Skip over type extension with 16 bytes
+				{
+					offset += 1 + 16;
+					return;
+				}
+
+				case 0xc7: // Skip over type extension with 8 bit header and bytes
+				{
+					int count = buffer[offset];
+					offset += count + 1 + 1;
+					return;
+				}
+
+				case 0xc8: // Skip over type extension with 16 bit header and bytes
+				{
+					int count = ByteUtil.BytesToShort(buffer, offset);
+					offset += count + 1 + 2;
+					return;
+				}
+
+				case 0xc9: // Skip over type extension with 32 bit header and bytes
+				{
+					int count = ByteUtil.BytesToInt(buffer, offset);
+					offset += count + 1 + 4;
+					return;
+				}
+
+				default:
+				{
+					if ((type & 0xe0) == 0xa0) // raw bytes with 8 bit combined header
+					{
+						offset += (type & 0x1f);
+						return;
+					}
+
+					if ((type & 0xf0) == 0x80) // map with 8 bit combined header
+					{
+						SkipMap(type & 0x0f);
+						return;
+					}
+
+					if ((type & 0xf0) == 0x90) // list with 8 bit combined header
+					{
+						SkipList(type & 0x0f);
+						return;
+					}
+
+					if (type < 0x80) // 8 bit combined unsigned integer
+					{
+						return;
+					}
+
+					if (type >= 0xe0) // 8 bit combined signed integer
+					{
+						return;
+					}
+
+					throw new IOException("Unknown unpack type: " + type);
+				}
+			}
+		}
+
+		private void SkipMap(int count)
+		{
+			for (; count > 0; --count)
+			{
+				SkipObject(); // key
+				SkipObject(); // value
+			}
+		}
+
+		private void SkipList(int count)
+		{
+			for (; count > 0; --count)
+			{
+				SkipObject();
+			}
+		}
+
+		private int SkipTypeExtensions(int itemCount)
+		{
+			for (; itemCount > 0; --itemCount)
+			{
+				int type = buffer[offset++];
+				switch (type)
+				{
+					case 0xd4: // Skip over type extension with 1 byte
+					{
+						offset += 1 + 1;
+						break;
+					}
+
+					case 0xd5: // Skip over type extension with 2 bytes
+					{
+						offset += 1 + 2;
+						break;
+					}
+
+					case 0xd6: // Skip over type extension with 4 bytes
+					{
+						offset += 1 + 4;
+						break;
+					}
+
+					case 0xd7: // Skip over type extension with 8 bytes
+					{
+						offset += 1 + 8;
+						break;
+					}
+
+					case 0xd8: // Skip over type extension with 16 bytes
+					{
+						offset += 1 + 16;
+						break;
+					}
+
+					case 0xc7: // Skip over type extension with 8 bit header and bytes
+					{
+						int count = buffer[offset];
+						offset += count + 1 + 1;
+						break;
+					}
+
+					case 0xc8: // Skip over type extension with 16 bit header and bytes
+					{
+						int count = ByteUtil.BytesToShort(buffer, offset);
+						offset += count + 1 + 2;
+						break;
+					}
+
+					case 0xc9: // Skip over type extension with 32 bit header and bytes
+					{
+						int count = ByteUtil.BytesToInt(buffer, offset);
+						offset += count + 1 + 4;
+						break;
+					}
+
+					default: // Not a type extension
+						--offset;
+						return itemCount;
+				}
+			}
+
+			return itemCount;
+		}
 	}
 }

--- a/Framework/AerospikeTest/AerospikeTest.csproj
+++ b/Framework/AerospikeTest/AerospikeTest.csproj
@@ -55,6 +55,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Sync\Basic\TestCustomParser.cs" />
     <Compile Include="Test.cs" />
     <Compile Include="Args.cs" />
     <Compile Include="Async\AsyncMonitor.cs" />

--- a/Framework/AerospikeTest/Sync/Basic/TestCustomParser.cs
+++ b/Framework/AerospikeTest/Sync/Basic/TestCustomParser.cs
@@ -39,13 +39,18 @@ namespace Aerospike.Test
 
 			public Record ParseRecord(byte[] dataBuffer, ref int dataOffset, int opCount, int generation, int expiration, bool isOperation)
 			{
+				string binName;
+				byte valueType;
+				int valueOffset;
+				int valueSize;
+
 				dataOffset = RecordParser.ExtractBinValue(
 					dataBuffer,
 					dataOffset,
-					out var binName,
-					out byte valueType,
-					out var valueOffset,
-					out var valueSize);
+					out binName,
+					out valueType,
+					out valueOffset,
+					out valueSize);
 
 				this.parseBin(dataBuffer.Skip(valueOffset).Take(valueSize).ToArray());
 				return new Record(null, generation, expiration);
@@ -80,7 +85,8 @@ namespace Aerospike.Test
 			Record record = Get(key, buffer =>
 			{
 				var unpacker = new Unpacker(buffer, 0, buffer.Length, false);
-				int count = unpacker.UnpackMapItemCount(out _);
+				MapOrder mapOrder;
+				int count = unpacker.UnpackMapItemCount(out mapOrder);
 				while (count-- > 0)
 				{
 					string k = unpacker.UnpackString();
@@ -207,7 +213,8 @@ namespace Aerospike.Test
 				Assert.AreEqual(list.Count, listCount);
 				Assert.AreEqual(list[0], unpacker.UnpackInteger());
 
-				int m1Count = unpacker.UnpackMapItemCount(out _);
+				MapOrder m1Order;
+				int m1Count = unpacker.UnpackMapItemCount(out m1Order);
 				Assert.AreEqual(m1.Count, m1Count);
 				var m1Keys = new HashSet<string>();
 				for (int i = 0; i < m1Count; ++i)
@@ -222,18 +229,24 @@ namespace Aerospike.Test
 							Assert.AreEqual(m1[k], unpacker.UnpackString());
 							break;
 						case "k1":
-							Assert.AreEqual(m11.Count, unpacker.UnpackMapItemCount(out _));
+						{
+							MapOrder k1Order;
+							Assert.AreEqual(m11.Count, unpacker.UnpackMapItemCount(out k1Order));
 							break;
+						}
 						case "k2":
 							Assert.AreEqual(l12.Count, unpacker.UnpackListItemCount());
 							Assert.AreEqual(l12[0], unpacker.UnpackInteger());
 							Assert.AreEqual(l12[1], unpacker.UnpackInteger());
 							break;
 						case "k3":
-							Assert.AreEqual(m13.Count, unpacker.UnpackMapItemCount(out _));
+						{
+							MapOrder k3Order;
+							Assert.AreEqual(m13.Count, unpacker.UnpackMapItemCount(out k3Order));
 							Assert.AreEqual("k131", unpacker.UnpackString());
 							Assert.AreEqual(m13["k131"], unpacker.UnpackInteger());
 							break;
+						}
 						default:
 							Assert.Fail($"unexpected m1 key: {k}");
 							break;

--- a/Framework/AerospikeTest/Sync/Basic/TestCustomParser.cs
+++ b/Framework/AerospikeTest/Sync/Basic/TestCustomParser.cs
@@ -1,0 +1,297 @@
+/* 
+ * Copyright 2012-2019 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Aerospike.Client;
+
+namespace Aerospike.Test
+{
+	[TestClass]
+	public class TestCustomParser : TestSync
+	{
+		private delegate void ParseBin(byte[] buffer);
+
+		private class BinParser : IRecordParser
+		{
+			private ParseBin parseBin;
+
+			public BinParser(ParseBin parseBin)
+			{
+				this.parseBin = parseBin;
+			}
+
+			public Record ParseRecord(byte[] dataBuffer, ref int dataOffset, int opCount, int generation, int expiration, bool isOperation)
+			{
+				dataOffset = RecordParser.ExtractBinValue(
+					dataBuffer,
+					dataOffset,
+					out var binName,
+					out byte valueType,
+					out var valueOffset,
+					out var valueSize);
+
+				this.parseBin(dataBuffer.Skip(valueOffset).Take(valueSize).ToArray());
+				return new Record(null, generation, expiration);
+			}
+		}
+
+		private Record Get(Key key, ParseBin parseBin)
+		{
+			var policy = new Policy() { recordParser = new BinParser(parseBin) };
+			return client.Get(policy, key);
+		}
+
+		[TestMethod]
+		public void UnpackMap()
+		{
+			Key key = new Key(args.ns, args.set, "customparser");
+			var map = new Dictionary<object, object>();
+
+			map.Add("k0", null);
+			map.Add("k1", 50L);
+			map.Add("k2", 5000L);
+			map.Add("k3", 5000000L);
+			map.Add("k4", "test");
+			map.Add("k5", "a loooooooooonger string");
+			map.Add("k6", 123.45);
+			map.Add("k7", -1234L);
+
+			Bin bin = new Bin(args.GetBinName("listmapbin"), map);
+			client.Put(null, key, bin);
+
+			var received = new Dictionary<object, object>();
+			Record record = Get(key, buffer =>
+			{
+				var unpacker = new Unpacker(buffer, 0, buffer.Length, false);
+				int count = unpacker.UnpackMapItemCount(out _);
+				while (count-- > 0)
+				{
+					string k = unpacker.UnpackString();
+					Assert.IsNotNull(k);
+					switch (k)
+					{
+						case "k0":
+						case "k1":
+						case "k2":
+						case "k3":
+						case "k7":
+						{
+							long? value = unpacker.UnpackInteger();
+							received.Add(k, value);
+							break;
+						}
+
+						case "k4":
+						case "k5":
+						{
+							string value = unpacker.UnpackString();
+							received.Add(k, value);
+							break;
+						}
+
+						case "k6":
+						{
+							double? value = unpacker.UnpackDouble();
+							received.Add(k, value);
+							break;
+						}
+
+						default:
+							Assert.Fail();
+							break;
+					}
+				}
+			});
+
+			Assert.IsTrue(record.generation > 0);
+			Assert.AreEqual(map.Count, received.Count);
+			foreach (var kv in map)
+			{
+				Assert.AreEqual(kv.Value, received[kv.Key], $"mismatch for key: {kv.Key}");
+			}
+		}
+
+		[TestMethod]
+		public void UnpackList()
+		{
+			Key key = new Key(args.ns, args.set, "customparser");
+			var list = new List<object>();
+
+			list.Add(null);
+			list.Add(50L);
+			list.Add(5000L);
+			list.Add(5000000L);
+			list.Add("test");
+			list.Add("a loooooooooonger string");
+			list.Add(123.45);
+			list.Add(-1234L);
+			list.Add(234.56F);
+			list.Add(true);
+			list.Add(false);
+
+			Bin bin = new Bin(args.GetBinName("listmapbin"), list);
+			client.Put(null, key, bin);
+
+			var received = new List<object>();
+			Record record = Get(key, buffer =>
+			{
+				var unpacker = new Unpacker(buffer, 0, buffer.Length, false);
+				int count = unpacker.UnpackListItemCount();
+				Assert.AreEqual(list.Count, count);
+				received.Add(unpacker.UnpackInteger());
+				received.Add(unpacker.UnpackInteger());
+				received.Add(unpacker.UnpackInteger());
+				received.Add(unpacker.UnpackInteger());
+				received.Add(unpacker.UnpackString());
+				received.Add(unpacker.UnpackString());
+				received.Add(unpacker.UnpackDouble());
+				received.Add(unpacker.UnpackInteger());
+				received.Add(unpacker.UnpackFloat());
+				received.Add(unpacker.UnpackBool());
+				received.Add(unpacker.UnpackBool());
+			});
+
+			Assert.IsTrue(record.generation > 0);
+			Assert.AreEqual(list.Count, received.Count);
+			for (int i = 0; i < list.Count; ++i)
+				Assert.AreEqual(list[i], received[i], $"mismatch for index: {i}");
+		}
+
+		[TestMethod]
+		public void UnpackComplex()
+		{
+			Key key = new Key(args.ns, args.set, "customparser");
+			var list = new List<object>();
+			var m1 = new Dictionary<object, object>();
+			var m11 = new Dictionary<object, object>();
+			var l12 = new List<object>();
+			var m13 = new Dictionary<object, object>();
+			var l2 = new List<object>();
+
+			list.Add(50L);
+			list.Add(m1);
+			list.Add(l2);
+			m1.Add("k0", "text");
+			m1.Add("k1", m11);
+			m1.Add("k2", l12);
+			m1.Add("k3", m13);
+			l12.Add(100L);
+			l12.Add(200L);
+			m13.Add("k131", 300L);
+			l2.Add("some more text");
+
+			Bin bin = new Bin(args.GetBinName("listmapbin"), list);
+			client.Put(null, key, bin);
+
+			Record record = Get(key, buffer =>
+			{
+				var unpacker = new Unpacker(buffer, 0, buffer.Length, false);
+				int listCount = unpacker.UnpackListItemCount();
+				Assert.AreEqual(list.Count, listCount);
+				Assert.AreEqual(list[0], unpacker.UnpackInteger());
+
+				int m1Count = unpacker.UnpackMapItemCount(out _);
+				Assert.AreEqual(m1.Count, m1Count);
+				var m1Keys = new HashSet<string>();
+				for (int i = 0; i < m1Count; ++i)
+				{
+					string k = unpacker.UnpackString();
+					Assert.IsFalse(m1Keys.Contains(k));
+					m1Keys.Add(k);
+
+					switch (k)
+					{
+						case "k0":
+							Assert.AreEqual(m1[k], unpacker.UnpackString());
+							break;
+						case "k1":
+							Assert.AreEqual(m11.Count, unpacker.UnpackMapItemCount(out _));
+							break;
+						case "k2":
+							Assert.AreEqual(l12.Count, unpacker.UnpackListItemCount());
+							Assert.AreEqual(l12[0], unpacker.UnpackInteger());
+							Assert.AreEqual(l12[1], unpacker.UnpackInteger());
+							break;
+						case "k3":
+							Assert.AreEqual(m13.Count, unpacker.UnpackMapItemCount(out _));
+							Assert.AreEqual("k131", unpacker.UnpackString());
+							Assert.AreEqual(m13["k131"], unpacker.UnpackInteger());
+							break;
+						default:
+							Assert.Fail($"unexpected m1 key: {k}");
+							break;
+					}
+				}
+
+				Assert.AreEqual(l2.Count, unpacker.UnpackListItemCount());
+				Assert.AreEqual(l2[0], unpacker.UnpackString());
+			});
+
+			Assert.IsTrue(record.generation > 0);
+		}
+
+		[TestMethod]
+		public void SkippingComplex()
+		{
+			Key key = new Key(args.ns, args.set, "customparser");
+			var list = new List<object>();
+			var m1 = new Dictionary<object, object>();
+			var m11 = new Dictionary<object, object>();
+			var l12 = new List<object>();
+			var m13 = new Dictionary<object, object>();
+			var l2 = new List<object>();
+
+			list.Add(50L);
+			list.Add(m1);
+			list.Add(null);
+			list.Add(l2);
+			list.Add(-12345L);
+			list.Add(12345L);
+			list.Add(123456789012345L);
+			list.Add(42424242L);
+			m1.Add("k0", "text");
+			m1.Add("k1", m11);
+			m1.Add("k2", l12);
+			m1.Add("k3", m13);
+			l12.Add(100L);
+			l12.Add(200L);
+			m13.Add("k131", 300L);
+			l2.Add("some more text");
+
+			Bin bin = new Bin(args.GetBinName("listmapbin"), list);
+			client.Put(null, key, bin);
+
+			Record record = Get(key, buffer =>
+			{
+				var unpacker = new Unpacker(buffer, 0, buffer.Length, false);
+				int listCount = unpacker.UnpackListItemCount();
+				Assert.AreEqual(list.Count, listCount);
+				unpacker.SkipObject(); // skip long
+				unpacker.SkipObject(); // skip m1
+				unpacker.SkipObject(); // skip null
+				unpacker.SkipObject(); // skip l2
+				unpacker.SkipObjects(3); // skip longs
+				Assert.AreEqual(list.Last(), unpacker.UnpackInteger());
+			});
+
+			Assert.IsTrue(record.generation > 0);
+		}
+	}
+}


### PR DESCRIPTION
This allows developers using custom record parsers to avoid unnecessary boxing/unboxing of values parsed into List<object> and Dictionary<object, object> structures, as well as skip these intermediate list/dictionaries completely if the target desired data structure is different anyway. Using low level parsing functions can dramatically reduce pressure on garbage collection as well as increase performance of parsing in general.