### PR TITLE
Avoid Stopwatch allocations in AsyncCommand

### DIFF
--- a/Framework/AerospikeClient/AerospikeClient.csproj
+++ b/Framework/AerospikeClient/AerospikeClient.csproj
@@ -394,6 +394,7 @@
     <Compile Include="Util\ThreadLocalData.cs" />
     <Compile Include="Util\Unpacker.cs" />
     <Compile Include="Util\Util.cs" />
+    <Compile Include="Util\ValueStopwatch.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/Framework/AerospikeClient/Util/ValueStopwatch.cs
+++ b/Framework/AerospikeClient/Util/ValueStopwatch.cs
@@ -6,15 +6,31 @@ namespace Aerospike.Client
     /// <summary>
     /// <see cref="Stopwatch"/> but as a struct.
     /// </summary>
-    internal readonly struct ValueStopwatch
+    internal struct ValueStopwatch
     {
-        private static readonly double TimestampTicksToMachineTicksRatio = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+        private static readonly double TimestampTicksPerMachineTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+        private static readonly double TimestampTicksPerMilliseconds = TimestampTicksPerMachineTicks / TimeSpan.TicksPerMillisecond;
 
         public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
 
         private readonly long startTimestamp;
 
-        public TimeSpan Elapsed => new TimeSpan((long)((Stopwatch.GetTimestamp() - startTimestamp) * TimestampTicksToMachineTicksRatio));
+        public bool IsRunning => startTimestamp != 0;
+
+        public int ElapsedMilliseconds
+        {
+            get
+            {
+                if (!IsRunning)
+                {
+                    throw new InvalidOperationException("Cannot get elapsed time of a non-running stopwatch");
+                }
+
+                long endTimestamp = Stopwatch.GetTimestamp();
+                long durationTimestamp = endTimestamp - startTimestamp;
+                return (int)(durationTimestamp * TimestampTicksPerMilliseconds);
+            }
+        }
 
         private ValueStopwatch(long startTimestamp) => this.startTimestamp = startTimestamp;
     }

--- a/Framework/AerospikeClient/Util/ValueStopwatch.cs
+++ b/Framework/AerospikeClient/Util/ValueStopwatch.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Aerospike.Client
+{
+    /// <summary>
+    /// <see cref="Stopwatch"/> but as a struct.
+    /// </summary>
+    internal readonly struct ValueStopwatch
+    {
+        private static readonly double TimestampTicksToMachineTicksRatio = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+
+        public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
+
+        private readonly long startTimestamp;
+
+        public TimeSpan Elapsed => new TimeSpan((long)((Stopwatch.GetTimestamp() - startTimestamp) * TimestampTicksToMachineTicksRatio));
+
+        private ValueStopwatch(long startTimestamp) => this.startTimestamp = startTimestamp;
+    }
+}


### PR DESCRIPTION
Each aerospike request can do several allocations that can easily end up in gen 2 so it's important to avoid any of these allocation when possible.