### PR TITLE
Allow commands to be GCed before end of timeout (fix #68)

### DIFF
--- a/Framework/AerospikeClient/Async/AsyncTimeoutQueue.cs
+++ b/Framework/AerospikeClient/Async/AsyncTimeoutQueue.cs
@@ -24,10 +24,10 @@ namespace Aerospike.Client
 	public sealed class AsyncTimeoutQueue
 	{
 		public static readonly AsyncTimeoutQueue Instance = new AsyncTimeoutQueue();
-		private const int MinInterval = 10;  // 10ms
+		private const int MIN_INTERVAL = 5;  // ms
 
-		private readonly ConcurrentQueue<ITimeout> queue = new ConcurrentQueue<ITimeout>();
-		private readonly LinkedList<ITimeout> list = new LinkedList<ITimeout>();
+		private readonly ConcurrentQueue<WeakReference<ITimeout>> queue = new ConcurrentQueue<WeakReference<ITimeout>>();
+		private readonly LinkedList<WeakReference<ITimeout>> list = new LinkedList<WeakReference<ITimeout>>();
 		private readonly Thread thread;
 		private CancellationTokenSource cancel;
 		private CancellationToken cancelToken;
@@ -43,20 +43,22 @@ namespace Aerospike.Client
 			cancel = new CancellationTokenSource();
 			cancelToken = cancel.Token;
 			valid = true;
-			thread = new Thread(new ThreadStart(this.Run));
-			thread.Name = "asynctimeout";
-			thread.IsBackground = true;
+			thread = new Thread(Run)
+			{
+				Name = "asynctimeout",
+				IsBackground = true,
+			};
 			thread.Start();
 		}
 
 		public void Add(ITimeout command, int timeout)
 		{
-			queue.Enqueue(command);
+			queue.Enqueue(new WeakReference<ITimeout>(command));
 
 			if (timeout < sleepInterval)
 			{
 				// Minimum sleep interval is 5ms.
-				sleepInterval = (timeout >= 5)? timeout : 5;
+				sleepInterval = Math.Max(timeout, MIN_INTERVAL);
 
 				lock (this)
 				{
@@ -99,16 +101,19 @@ namespace Aerospike.Client
 
 		private void RegisterCommands()
 		{
-			ITimeout command;
-			while (queue.TryDequeue(out command))
+			while (queue.TryDequeue(out WeakReference<ITimeout> commandRef))
 			{
-				list.AddLast(command);
+				// Don't add if the command was garbage collected.
+				if (commandRef.TryGetTarget(out _))
+				{
+					list.AddLast(commandRef);
+				}
 			}
 		}
 
 		private void CheckTimeouts()
 		{
-			LinkedListNode<ITimeout> node = list.First;
+			LinkedListNode<WeakReference<ITimeout>> node = list.First;
 
 			if (node == null)
 			{
@@ -117,17 +122,17 @@ namespace Aerospike.Client
 				return;
 			}
 
-			LinkedListNode<ITimeout> last = list.Last;
+			LinkedListNode<WeakReference<ITimeout>> last = list.Last;
 
 			while (node != null)
 			{
 				list.RemoveFirst();
 
-				ITimeout command = node.Value;
+				WeakReference<ITimeout> commandRef = node.Value;
 
-				if (command.CheckTimeout())
+				if (commandRef.TryGetTarget(out ITimeout command) && command.CheckTimeout())
 				{
-					list.AddLast(command);
+					list.AddLast(commandRef);
 				}
 
 				if (node == last)


### PR DESCRIPTION
# Problem

When using a large timeout (e.g. with a `totalTimeout` of 0, the `socketTimeout` is used which defaults to 30s) the objects are kept for the duration of the timeout in memory (in `AsyncTimeoutPool.queue`). This leads to the whole command (`Key`, `StringValue`, `string`, `AsyncRead`, `Partition`, `RecordListenerAdapter`, `TaskCompletionSource`, `Task`, `Record, Dictionary<string, object>`) to reach gen 2, putting lots of pression on the garbage collector.

# Solution

A solution could be that every time a command complete, it's removed from the `AsyncTimeoutQueue` but it's difficult to do that in a thread safe and performant way.

The proposed solution here is for the `AsyncTimeoutQueue` to use a weak reference to the command so that when the command completes it can be garbage collected. The WeakReference instance will still reach gen 2 but it could be pooled in a future change.

# Test

```csharp
using Aerospike.Client;

Log.SetCallbackStandard();

AsyncClient client = new(new AsyncClientPolicy
{
    tlsPolicy = new TlsPolicy { forLoginOnly = true, },
    authMode = AuthMode.EXTERNAL,
    user = "XXX",
    password = "XXX",
    asyncMaxCommandAction = MaxCommandAction.DELAY,
    asyncMaxCommandsInQueue = 100000,
    asyncMinConnsPerNode = 0,
    asyncMaxConnsPerNode = 300,
    maxConnsPerNode = 300,
    maxErrorRate = 100,
    maxSocketIdle = 0,
    tendInterval = 5000,
    timeout = 5000,
    loginTimeout = 10000,
}, new Host("XXX", "XXX", 4333));

Policy policy = new()
{
    maxRetries = 0,
    totalTimeout = 0,
};

for (int i = 0; i < 10_000; i += 1)
{
    Key k = new("ns00", "test", i.ToString());
    await client.Get(policy, CancellationToken.None, k);
    await Task.Delay(10);
```

Running this code in my machine before and after the change and comparing two dotmemory dumps taken with a 1 minute interval gives these results:
![dotmemory](https://user-images.githubusercontent.com/9092290/182864412-f518e495-440a-4303-b457-3b0f4042a311.png)
After the change all the aerospike disappear from the gen 2, only the WeakReferences remain.

# Conclusion

The results are very promising for the few lines of code changed. To go further we could introduce a pool of WeakReferences.

What do you think @BrianNichols ?