### PR TITLE
Fix excessive allocations in PartitionParser

### DIFF
--- a/AerospikeClient/Cluster/PartitionParser.cs
+++ b/AerospikeClient/Cluster/PartitionParser.cs
@@ -14,8 +14,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-using System;
-using System.Collections.Generic;
+
+using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
 using System.Text;
 
 namespace Aerospike.Client
@@ -192,8 +194,12 @@ namespace Aerospike.Client
 		{
 			Node[] nodeArray = partitions.replicas[index];
 			int[] regimes = partitions.regimes;
-			char[] chars = Encoding.ASCII.GetChars(buffer, begin, offset - begin);
-			byte[] restoreBuffer = Convert.FromBase64CharArray(chars, 0, chars.Length);
+
+			Span<byte> bufferChars = buffer.AsSpan(start: begin, length: offset - begin);
+			Span<byte> restoreBuffer = stackalloc byte[Base64.GetMaxDecodedFromUtf8Length(bufferChars.Length)];
+			var decodeStatus = Base64.DecodeFromUtf8(bufferChars, restoreBuffer, out _, out int restoreBufferLength);
+			Debug.Assert(decodeStatus == OperationStatus.Done);
+			restoreBuffer = restoreBuffer[..restoreBufferLength]; // To get proper exception for out-of-bounds access.
 
 			for (int i = 0; i < partitionCount; i++)
 			{

--- a/AerospikeClient/Cluster/PartitionParser.cs
+++ b/AerospikeClient/Cluster/PartitionParser.cs
@@ -196,6 +196,7 @@ namespace Aerospike.Client
 			int[] regimes = partitions.regimes;
 
 			Span<byte> bufferChars = buffer.AsSpan(start: begin, length: offset - begin);
+			bufferChars = bufferChars.TrimEnd((byte)'\n');
 			Span<byte> restoreBuffer = stackalloc byte[Base64.GetMaxDecodedFromUtf8Length(bufferChars.Length)];
 			var decodeStatus = Base64.DecodeFromUtf8(bufferChars, restoreBuffer, out _, out int restoreBufferLength);
 			Debug.Assert(decodeStatus == OperationStatus.Done);

--- a/AerospikeClient/Main/Info.cs
+++ b/AerospikeClient/Main/Info.cs
@@ -19,7 +19,6 @@ using System.Text;
 using System.Net;
 using System.Net.Sockets;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace Aerospike.Client
 {
@@ -580,13 +579,14 @@ namespace Aerospike.Client
 		public void ParseName(string name)
 		{
 			int begin = offset;
-			ReadOnlySpan<byte> nameBytes = MemoryMarshal.AsBytes(name.AsSpan());
 
 			while (offset < length)
 			{
 				if (buffer[offset] == '\t')
 				{
-					if (nameBytes.SequenceEqual(buffer.AsSpan(start: begin, length: offset - begin)))
+					String s = ByteUtil.Utf8ToString(buffer, begin, offset - begin);
+
+					if (name.Equals(s))
 					{
 						offset++;
 

--- a/AerospikeClient/Main/Info.cs
+++ b/AerospikeClient/Main/Info.cs
@@ -19,6 +19,7 @@ using System.Text;
 using System.Net;
 using System.Net.Sockets;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace Aerospike.Client
 {
@@ -579,14 +580,13 @@ namespace Aerospike.Client
 		public void ParseName(string name)
 		{
 			int begin = offset;
+			ReadOnlySpan<byte> nameBytes = MemoryMarshal.AsBytes(name.AsSpan());
 
 			while (offset < length)
 			{
 				if (buffer[offset] == '\t')
 				{
-					String s = ByteUtil.Utf8ToString(buffer, begin, offset - begin);
-
-					if (name.Equals(s))
+					if (nameBytes.SequenceEqual(buffer.AsSpan(start: begin, length: offset - begin)))
 					{
 						offset++;
 


### PR DESCRIPTION
These allocations represent 18% of the total allocation size of our biggest service. Since Aerospike now targets .NET 6 we can use such optimizations.