### PR TITLE
Allowing inner Exception to be null in AerospikeException constructor

### DIFF
--- a/AerospikeClient/Main/AerospikeException.cs
+++ b/AerospikeClient/Main/AerospikeException.cs
@@ -36,7 +36,7 @@ namespace Aerospike.Client
 		}
 
 		public AerospikeException(int resultCode, Exception e)
-			: base(e.Message, e)
+			: base(e?.Message ?? string.Empty, e)
 		{
 			this.resultCode = resultCode;
 		}


### PR DESCRIPTION
[Several AerospikeException.Timeout constructors](https://github.com/aerospike/aerospike-client-csharp/blob/master/AerospikeClient/Main/AerospikeException.cs#L270) take an optional inner exception, by default null. 

However they use this AerospikeException constructor for their base classes, which can't deal with a null Exception argument.

Right now, using these AerospikeException.Timeout constructors without specifying an Inner Exception will result in an "Object reference not set to an instance of an object" error if no inner exception is given.

This happens at several places at least within [Aerospike.Client.AsyncCommand.cs](https://github.com/aerospike/aerospike-client-csharp/blob/master/AerospikeClient/Async/AsyncCommand.cs#L819).