### PR TITLE
Avoid heap allocations in `ValueRipemd160`

### DIFF
--- a/AerospikeClient/Util/Hash.cs
+++ b/AerospikeClient/Util/Hash.cs
@@ -44,9 +44,7 @@ namespace Aerospike.Client
 			// Benchmarks show creating instance every time is faster than thread local
 			// implementation because instance implementation puts ValueRipemd160 on
 			// stack (fast) and eliminates the overhead of retrieving thread local instance.
-			ValueRipemd160 ripe = new ValueRipemd160();
-			ripe.Add(buffer, 0, length);
-			return ripe.HashDigest();
+			return ValueRipemd160.ComputeHashDigest(buffer.AsSpan(0, length));
 		}
 #endif
 	}

--- a/AerospikeClient/Util/ValueRipemd160.cs
+++ b/AerospikeClient/Util/ValueRipemd160.cs
@@ -32,6 +32,7 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 using System;
 
 namespace Aerospike.Client
@@ -43,10 +44,10 @@ namespace Aerospike.Client
 	/// This is an optimized implementation based on Bouncy Castle's RipeMD160Digest.cs:
 	/// http://www.bouncycastle.org/csharp
 	/// </summary>
-	public struct ValueRipemd160
+	public ref struct ValueRipemd160
 	{
-		private uint[] X = new uint[16];
-		private byte[] xBuf = new byte[4];
+		private Span<uint> X;
+		private Span<byte> xBuf;
 		private int xOff = 0;
 		private int xBufOff = 0;
 		private long byteCount = 0;
@@ -56,8 +57,29 @@ namespace Aerospike.Client
 		private uint H3 = 0x10325476;
 		private uint H4 = 0xc3d2e1f0;
 
+		public static byte[] ComputeHashDigest(ReadOnlySpan<byte> input)
+		{
+			Span<uint> x = stackalloc uint[16];
+			Span<byte> xBuf = stackalloc byte[4];
+			// The content of the memory allocated by stackalloc is undefined, so we explicitly clear it.
+			x.Clear();
+			xBuf.Clear();
+			ValueRipemd160 ripe = new(x, xBuf);
+			ripe.Add(input);
+			return ripe.HashDigest();
+		}
+
 		public ValueRipemd160()
 		{
+			// fallback implementation
+			X = new uint[16];
+			xBuf = new byte[4];
+		}
+
+		public ValueRipemd160(Span<uint> x, Span<byte> xBuf)
+		{
+			this.X = x;
+			this.xBuf = xBuf;
 		}
 
 		/// <summary>
@@ -67,8 +89,8 @@ namespace Aerospike.Client
 		/// </summary>
 		public void Reset()
 		{
-			Array.Clear(X, 0, X.Length);
-			Array.Clear(xBuf, 0, xBuf.Length);
+			X.Clear();
+			xBuf.Clear();
 			xOff = 0;
 			xBufOff = 0;
 			byteCount = 0;
@@ -82,15 +104,15 @@ namespace Aerospike.Client
 		/// <summary>
 		/// Add bytes to be hashed.
 		/// </summary>
-		public void Add(byte[] input, int inOff, int length)
+		public void Add(ReadOnlySpan<byte> input)
 		{
 			// fill the current word
 			int i = 0;
 			if (xBufOff != 0)
 			{
-				while (i < length)
+				while (i < input.Length)
 				{
-					xBuf[xBufOff++] = input[inOff + i++];
+					xBuf[xBufOff++] = input[i++];
 					if (xBufOff == 4)
 					{
 						ProcessWord(xBuf, 0);
@@ -101,19 +123,19 @@ namespace Aerospike.Client
 			}
 
 			// process whole words.
-			int limit = ((length - i) & ~3) + i;
+			int limit = ((input.Length - i) & ~3) + i;
 			for (; i < limit; i += 4)
 			{
-				ProcessWord(input, inOff + i);
+				ProcessWord(input, i);
 			}
 
 			// load in the remainder.
-			while (i < length)
+			while (i < input.Length)
 			{
-				xBuf[xBufOff++] = input[inOff + i++];
+				xBuf[xBufOff++] = input[i++];
 			}
 
-			byteCount += length;
+			byteCount += input.Length;
 		}
 
 		/// <summary>
@@ -136,18 +158,19 @@ namespace Aerospike.Client
 		/// Return hash digest for bytes that have been added up to this point.
 		/// </summary>
 		public byte[] HashDigest()
-        {
-            long bitLength = (byteCount << 3);
+		{
+			long bitLength = (byteCount << 3);
 
-            // add the pad bytes.
-            Add((byte)128);
+			// add the pad bytes.
+			Add((byte)128);
 
 			while (xBufOff != 0)
 			{
 				Add((byte)0);
 			}
-            ProcessLength(bitLength);
-            ProcessBlock();
+
+			ProcessLength(bitLength);
+			ProcessBlock();
 
 			return new byte[]
 			{
@@ -172,14 +195,14 @@ namespace Aerospike.Client
 				(byte)(H4 >> 16),
 				(byte)(H4 >> 24)
 			};
-        }
+		}
 
-		private void ProcessWord(byte[] input, int inOff)
+		private void ProcessWord(ReadOnlySpan<byte> input, int inOff)
 		{
 			X[xOff++] = ((uint)input[inOff]) |
-						(((uint)input[inOff + 1]) << 8) |
-						(((uint)input[inOff + 2]) << 16) |
-						(((uint)input[inOff + 3]) << 24);
+			            (((uint)input[inOff + 1]) << 8) |
+			            (((uint)input[inOff + 2]) << 16) |
+			            (((uint)input[inOff + 3]) << 24);
 
 			if (xOff == 16)
 			{
@@ -1029,7 +1052,7 @@ namespace Aerospike.Client
 
 			// Reset the offset and clean out the word buffer.
 			xOff = 0;
-			Array.Clear(X, 0, X.Length);
+			X.Clear();
 		}
 	}
 }


### PR DESCRIPTION
**Problems**

The `Ripemd160` class was replaced by `ValueRipemd160` in PR #121. However, this change presents a few issues:

- `ValueRipemd160` is defined as a struct, yet it contains array fields allocated on the heap.
- Being a mutable struct, instances of `ValueRipemd160` will have invalid states when copied, which constitutes a breaking change.

**Solutions**

To address these issues, the following solutions are proposed:

- Change the definition of `ValueRipemd160` from `struct` to `ref struct`. By imposing the constraint that this struct can only exist on the stack, it reduces the possibility of common mistakes such as unintended defensive copying, and enables the use of stack space as a buffer.
- Introduce a static `ComputeHashDigest(Span<byte>)` method for safer and simpler computation of RIPEMD-160 hash. Since handling mutable structs and stack-based buffers is prone to errors, this method allows for simple use cases without directly manipulating instances of the `ValueRipemd160` struct.
- Replace internal buffers with `Span<T>` instead of arrays, allowing stack allocation. By passing buffers allocated on the stack using `stackalloc` as `Span<T>` to the constructor, heap allocation can be completely avoided.

**Benchmark**

```

BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3672/23H2/2023Update/SunValley3)
AMD Ryzen 9 7940HS w/ Radeon 780M Graphics, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.300
  [Host]   : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  ShortRun : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```
| Method                   | InputLength | Mean     | Error    | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
|------------------------- |------------ |---------:|---------:|--------:|------:|-------:|----------:|------------:|
| Ripemd160                | 10          | 331.3 ns | 11.60 ns | 0.64 ns |  1.00 | 0.0286 |     240 B |        1.00 |
| ValueRipemd160           | 10          | 298.0 ns | 15.36 ns | 0.84 ns |  0.90 | 0.0200 |     168 B |        0.70 |
| ValueRipemd160_Optimized | 10          | 289.9 ns | 22.06 ns | 1.21 ns |  0.87 | 0.0057 |      48 B |        0.20 |
|                          |             |          |          |         |       |        |           |             |
| Ripemd160                | 100         | 605.8 ns | 23.67 ns | 1.30 ns |  1.00 | 0.0286 |     240 B |        1.00 |
| ValueRipemd160           | 100         | 599.9 ns | 14.31 ns | 0.78 ns |  0.99 | 0.0200 |     168 B |        0.70 |
| ValueRipemd160_Optimized | 100         | 584.5 ns | 18.50 ns | 1.01 ns |  0.96 | 0.0057 |      48 B |        0.20 |

**Benchmark code**

```cs
public class Bench
{
    [Params(10, 100)]
    public int InputLength;

    private byte[] data;

    [GlobalSetup]
    public void GlobalSetup()
    {
        data = new byte[InputLength];
        Random.Shared.NextBytes(data);
    }
    
    [Benchmark(Baseline = true)]
    public byte[] Ripemd160()
    {
        Ripemd160 ripe = new();
        ripe.Add(data, 0, data.Length);
        return ripe.HashDigest();
    }
    
    [Benchmark()]
    public byte[] ValueRipemd160()
    {
        ValueRipemd160 ripe = new();
        ripe.Add(data, 0, data.Length);
        return ripe.HashDigest();
    }
    
    [Benchmark()]
    public byte[] ValueRipemd160_Optimized()
    {
        return Ripemd160Benchmark.ValueRipemd160_Optimized.ComputeHashDigest(data);
    }
}
```