### PR TITLE
Optionally do not throw exception from Touch command when record does not exist

### DIFF
--- a/AerospikeClient/Command/TouchCommand.cs
+++ b/AerospikeClient/Command/TouchCommand.cs
@@ -65,6 +65,15 @@ namespace Aerospike.Client
 				return;
 			}
 
+			if (resultCode == ResultCode.KEY_NOT_FOUND_ERROR)
+			{
+				if (writePolicy.failOnTouchRecordDoesNotExist)
+				{
+					throw new AerospikeException(resultCode);
+				}
+				return;
+			}
+
 			if (resultCode == ResultCode.FILTERED_OUT)
 			{
 				if (writePolicy.failOnFilteredOut)

--- a/AerospikeClient/Policy/WritePolicy.cs
+++ b/AerospikeClient/Policy/WritePolicy.cs
@@ -99,11 +99,22 @@ namespace Aerospike.Client
 		/// <para>Default: false (do not tombstone deleted records).</para>
 		/// </summary>
 		public bool durableDelete;
-	
+
 		/// <summary>
-		/// Copy write policy from another write policy.
+		/// Qualify how to handle touches when the record does not exist.
+		/// If true, throw <see cref="Aerospike.Client.AerospikeException"/>
+		/// with result code <seealso cref="Aerospike.Client.ResultCode.KEY_NOT_FOUND_ERROR"/>;
+		/// otherwise, do nothing.
+		/// <para>
+		/// Default: true
+		/// </para>
 		/// </summary>
-		public WritePolicy(WritePolicy other)
+		public bool failOnTouchRecordDoesNotExist = true;
+
+        /// <summary>
+        /// Copy write policy from another write policy.
+        /// </summary>
+        public WritePolicy(WritePolicy other)
 			: base(other)
 		{
 			this.recordExistsAction = other.recordExistsAction;
@@ -113,7 +124,8 @@ namespace Aerospike.Client
 			this.expiration = other.expiration;
 			this.respondAllOps = other.respondAllOps;
 			this.durableDelete = other.durableDelete;
-		}
+			this.failOnTouchRecordDoesNotExist = other.failOnTouchRecordDoesNotExist;
+        }
 
 		/// <summary>
 		/// Copy write policy from another policy.

--- a/AerospikeClient/Policy/WritePolicy.cs
+++ b/AerospikeClient/Policy/WritePolicy.cs
@@ -111,10 +111,10 @@ namespace Aerospike.Client
 		/// </summary>
 		public bool failOnTouchRecordDoesNotExist = true;
 
-        /// <summary>
-        /// Copy write policy from another write policy.
-        /// </summary>
-        public WritePolicy(WritePolicy other)
+		/// <summary>
+		/// Copy write policy from another write policy.
+		/// </summary>
+		public WritePolicy(WritePolicy other)
 			: base(other)
 		{
 			this.recordExistsAction = other.recordExistsAction;

--- a/AerospikeTest/Sync/Basic/TestTouch.cs
+++ b/AerospikeTest/Sync/Basic/TestTouch.cs
@@ -56,6 +56,18 @@ namespace Aerospike.Test
 
 			record = client.Get(null, key, bin.name);
 			Assert.IsNull(record);
-		}
+
+			try
+			{
+				client.Touch(writePolicy, key);
+				Assert.Fail("Must throw ResultCode.KEY_NOT_FOUND_ERROR exception.");
+			}
+			catch (AerospikeException ex) when (ex.Result == ResultCode.KEY_NOT_FOUND_ERROR)
+			{
+			}
+
+			writePolicy.failOnTouchRecordDoesNotExist = false;
+			client.Touch(writePolicy, key);
+        }
 	}
 }


### PR DESCRIPTION
Add `failOnTouchRecordDoesNotExist` parameter to `WritePolicy` to optionally not throw an exception when touching records that do not exist.

Remove exception-handling overhead associated with touching expired records in high-volume applications.

Default value is `true` to keep compatibility with existing behavior.