### PR TITLE
Fixes to Pool<T> class, load balancer detection and AsyncOperateWrite 

### DIFF
--- a/AerospikeClient/Async/AsyncOperateWrite.cs
+++ b/AerospikeClient/Async/AsyncOperateWrite.cs
@@ -35,6 +35,7 @@ namespace Aerospike.Client
 		public AsyncOperateWrite(AsyncOperateWrite other)
 			: base(other)
 		{
+			this.listener = other.listener;
 			this.args = other.args;
 		}
 

--- a/AerospikeClient/Cluster/NodeValidator.cs
+++ b/AerospikeClient/Cluster/NodeValidator.cs
@@ -230,7 +230,10 @@ namespace Aerospike.Client
 						// Disable load balancer detection for localhost.
 						detectLoadBalancer = false;
 					}
-					
+				}
+
+				if (detectLoadBalancer)
+				{
 					// Seed may be load balancer with changing address. Determine real address.
 					addressCommand = (cluster.tlsPolicy != null) ?
 						cluster.useServicesAlternate ? "service-tls-alt" : "service-tls-std" :

--- a/AerospikeClient/Cluster/Pool.cs
+++ b/AerospikeClient/Cluster/Pool.cs
@@ -154,7 +154,7 @@ namespace Aerospike.Client
 					return default;
 				}
 
-				return items[head];
+				return items[head == 0 ? items.Length - 1 : head - 1];
 			}
 			finally
 			{


### PR DESCRIPTION
This request consists of three changes:

1. Fix to Pool<T>.PeekFirst function. The current implementation looks for data at wrong location.
2. Changes to load balancer detection in NodeValidator.ValidateAddress function. The current implementation disables load balance detection for local addresses, but proceeds with it anyway, resulting in failing connections in local test environments.
3. When AsyncOperateWrite is cloned (happens when the connection is lost), the listener is not copied, resulting in calling thread never be notified about command completion.