### PR TITLE
CLIENT-3255: Setup TestCategory for SCMode and Enterprise tests

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -75,10 +75,6 @@ jobs:
         cd AerospikeClient
         dotnet restore
         dotnet build -p:UseSharedCompilation=false --configuration Release
-        
-        cd ../AerospikeClientProxy
-        dotnet restore
-        dotnet build -p:UseSharedCompilation=false --configuration Release
 
     - name: Perform CodeQL Analysis     
       uses: github/codeql-action/analyze@v2

--- a/AerospikeTest/Async/TestAsyncTxn.cs
+++ b/AerospikeTest/Async/TestAsyncTxn.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2012-2018 Aerospike, Inc.
+ * Copyright 2012-2025 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.

--- a/AerospikeTest/Async/TestAsyncTxn.cs
+++ b/AerospikeTest/Async/TestAsyncTxn.cs
@@ -23,7 +23,7 @@ using static Aerospike.Client.AbortStatus;
 
 namespace Aerospike.Test
 {
-	[TestClass]
+	[TestClass, TestCategory("SCMode")]
 	public class TestAsyncTxn : TestAsync
 	{
 		private static readonly string binName = "bin";

--- a/AerospikeTest/Sync/Basic/TestPutGet.cs
+++ b/AerospikeTest/Sync/Basic/TestPutGet.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2012-2024 Aerospike, Inc.
+ * Copyright 2012-2025 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.

--- a/AerospikeTest/Sync/Basic/TestTxn.cs
+++ b/AerospikeTest/Sync/Basic/TestTxn.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2012-2018 Aerospike, Inc.
+ * Copyright 2012-2025 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.

--- a/AerospikeTest/Sync/Basic/TestTxn.cs
+++ b/AerospikeTest/Sync/Basic/TestTxn.cs
@@ -21,7 +21,7 @@ using System.Text;
 
 namespace Aerospike.Test
 {
-	[TestClass]
+	[TestClass, TestCategory("SCMode")]
 	public class TestTxn : TestSync
 	{
 		private static readonly string binName = "bin";


### PR DESCRIPTION
Run `dotnet test` with `--filter "TestCategory!=Enterprise"` to skip compression test or `--filter "TestCategory!=SCMode"` to skip MRT tests