### PR TITLE
CLIENT-3319: Handle hostname in addition to IP address in peers returned by the server

### DIFF
--- a/AerospikeClient/Cluster/Node.cs
+++ b/AerospikeClient/Cluster/Node.cs
@@ -491,7 +491,8 @@ namespace Aerospike.Client
 							IPAddress[] addresses = Dns.GetHostAddresses(h.name);
 							foreach (IPAddress address in addresses)
 							{
-								if (address.Equals(node.address.Address))
+								if (address.Equals(node.address.Address) ||
+									IPAddress.IsLoopback(address))
 								{
 									// Set peer hostname for faster future lookups.
 									node.hostname = h.name;

--- a/AerospikeClient/Cluster/Node.cs
+++ b/AerospikeClient/Cluster/Node.cs
@@ -1,5 +1,5 @@
 /* 
- * Copyright 2012-2024 Aerospike, Inc.
+ * Copyright 2012-2025 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.
@@ -14,12 +14,8 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-using System;
 using System.Net;
-using System.Threading;
-using System.Collections.Generic;
 using static Aerospike.Client.Latency;
-using System.Xml.Linq;
 using System.Net.Sockets;
 
 namespace Aerospike.Client
@@ -44,8 +40,8 @@ namespace Aerospike.Client
 
 		protected internal readonly Cluster cluster;
 		private readonly string name;
-		protected internal readonly Host host;
-		protected internal readonly List<Host> aliases;
+		protected string hostname; // Optional hostname
+		protected internal readonly Host host; // Host with IP address name
 		protected internal readonly IPEndPoint address;
 		private Connection tendConnection;
 		private byte[] sessionToken;
@@ -83,7 +79,6 @@ namespace Aerospike.Client
 		{
 			this.cluster = cluster;
 			this.name = nv.name;
-			this.aliases = nv.aliases;
 			this.host = nv.primaryHost;
 			this.address = nv.primaryAddress;
 			this.tendConnection = nv.primaryConn;
@@ -424,7 +419,11 @@ namespace Aerospike.Client
 
 							if (peer.replaceNode != null)
 							{
-								peers.removeList.Add(peer.replaceNode);
+								if (Log.InfoEnabled())
+								{
+									Log.Info("Replace node: " + peer.replaceNode);
+								}
+								peers.removeNodes.Add(peer.replaceNode);
 							}
 							break;
 						}
@@ -475,12 +474,38 @@ namespace Aerospike.Client
 				// Match peer hosts with the node host.
 				foreach (Host h in peer.hosts)
 				{
-					if (h.Equals(node.host))
+					if (h.port == node.host.port)
 					{
-						// Main node host is also the same as one of the peer hosts.
-						// Peer should not be added.
-						node.referenceCount++;
-						return true;
+						// Check for IP address (node.host.name is an IP address) or hostname if it exists.
+						if (h.name.Equals(node.host.name) || (node.hostname != null && h.name == node.hostname))
+						{
+							// Main node host is also the same as one of the peer hosts.
+							// Peer should not be added.
+							node.referenceCount++;
+							return true;
+						}
+
+						// Peer name might be a hostname. Get peer IP addresses and check with node IP address.
+						try
+						{
+							IPAddress[] addresses = Dns.GetHostAddresses(h.name);
+							foreach (IPAddress address in addresses)
+							{
+								if (address.Equals(node.address.Address))
+								{
+									// Set peer hostname for faster future lookups.
+									node.hostname = h.name;
+									node.referenceCount++;
+									return true;
+								}
+							}
+						}
+						catch (Exception)
+						{
+							// Peer name is invalid. replaceNode may be set, but that node will
+							// not be replaced because NodeValidator will reject it.
+							Log.Error("Invalid peer received by cluster tend: " + h.name);
+						}
 					}
 				}
 

--- a/AerospikeClient/Cluster/NodeValidator.cs
+++ b/AerospikeClient/Cluster/NodeValidator.cs
@@ -1,5 +1,5 @@
 /* 
- * Copyright 2012-2024 Aerospike, Inc.
+ * Copyright 2012-2025 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.
@@ -14,9 +14,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-using System;
 using System.Net;
-using System.Collections.Generic;
 
 namespace Aerospike.Client
 {
@@ -24,7 +22,6 @@ namespace Aerospike.Client
 	{
 		internal Node fallback;
 		internal string name;
-		internal List<Host> aliases;
 		internal Host primaryHost;
 		internal IPEndPoint primaryAddress;
 		internal Connection primaryConn;
@@ -40,7 +37,6 @@ namespace Aerospike.Client
 		public Node SeedNode(Cluster cluster, Host host, Peers peers)
 		{
 			name = null;
-			aliases = null;
 			primaryHost = null;
 			primaryAddress = null;
 			primaryConn = null;
@@ -57,12 +53,6 @@ namespace Aerospike.Client
 				try
 				{
 					ValidateAddress(cluster, address, host.tlsName, host.port, true);
-
-					// Only set aliases when they were not set by load balancer detection logic.
-					if (this.aliases == null)
-					{
-						SetAliases(address, host.tlsName, host.port);
-					}
 
 					Node node = cluster.CreateNode(this, false);
 
@@ -156,7 +146,6 @@ namespace Aerospike.Client
 				try
 				{
 					ValidateAddress(cluster, address, host.tlsName, host.port, false);
-					SetAliases(address, host.tlsName, host.port);
 					return;
 				}
 				catch (Exception e)
@@ -425,7 +414,6 @@ namespace Aerospike.Client
 								}
 
 								// Authenticated connection.  Set real host.
-								SetAliases(address, tlsName, h.port);
 								this.primaryHost = new Host(address.ToString(), tlsName, h.port);
 								this.primaryAddress = socketAddress;
 								this.primaryConn.Close();
@@ -456,13 +444,6 @@ namespace Aerospike.Client
 			{
 				Log.Info(cluster.context, "Invalid address " + result + ". access-address is probably not configured on server.");
 			}
-		}
-		
-		private void SetAliases(IPAddress address, string tlsName, int port)
-		{
-			// Add capacity for current address plus IPV6 address and hostname.
-			this.aliases = new List<Host>(3);
-			this.aliases.Add(new Host(address.ToString(), tlsName, port));
 		}
 	}
 

--- a/AerospikeClient/Cluster/Peers.cs
+++ b/AerospikeClient/Cluster/Peers.cs
@@ -1,5 +1,5 @@
 /* 
- * Copyright 2012-2024 Aerospike, Inc.
+ * Copyright 2012-2025 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.
@@ -14,8 +14,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace Aerospike.Client
@@ -24,7 +22,7 @@ namespace Aerospike.Client
 	{
 		public readonly List<Peer> peers;
 		public readonly Dictionary<string, Node> nodes;
-		public readonly List<Node> removeList;
+		public readonly HashSet<Node> removeNodes;
 		private readonly HashSet<Host> invalidHosts;
 		public int refreshCount;
 		public bool genChanged;
@@ -34,7 +32,7 @@ namespace Aerospike.Client
 			peers = new List<Peer>(peerCapacity);
 			nodes = new Dictionary<string, Node>();
 			invalidHosts = new HashSet<Host>();
-			removeList = new List<Node>();
+			removeNodes = new HashSet<Node>();
 		}
 
 		public bool HasFailed(Host host)


### PR DESCRIPTION
If the peers host string does not match the node IP address string, check the peers host IP addresses with the node address instead.
Change "List<Node> removeList" to "HashSet<Node> removeNodes" to prevent the same node from being added multiple times.
Remove unused cluster and node aliases collection.