### PR TITLE
Support Memory<byte> values

### DIFF
--- a/AerospikeClient/Util/Packer.cs
+++ b/AerospikeClient/Util/Packer.cs
@@ -147,16 +147,19 @@ namespace Aerospike.Client
 
 		public void PackParticleBytes(byte[] b)
 		{
-			PackByteArrayBegin(b.Length + 1);
-			PackByte((int)ParticleType.BLOB);
-			PackByteArray(b, 0, b.Length);
+			PackParticleBytes(b.AsMemory());
 		}
 
 		public void PackParticleBytes(byte[] b, int offset, int length)
 		{
-			PackByteArrayBegin(length + 1);
+			PackParticleBytes(b.AsMemory(offset, length));
+		}
+
+		public void PackParticleBytes(ReadOnlyMemory<byte> b)
+		{
+			PackByteArrayBegin(b.Length + 1);
 			PackByte((int)ParticleType.BLOB);
-			PackByteArray(b, offset, length);
+			PackByteArray(b);
 		}
 
 		public void PackBlob(object val)
@@ -436,15 +439,21 @@ namespace Aerospike.Client
 				PackInt(0xdb, (uint)size);
 			}
 		}
-		
+
 		public void PackByteArray(byte[] src, int srcOffset, int srcLength)
 		{
-			if (offset + srcLength > buffer.Length)
+			PackByteArray(src.AsMemory(srcOffset, srcLength));
+		}
+
+		public void PackByteArray(ReadOnlyMemory<byte> src)
+		{
+			if (offset + src.Length > buffer.Length)
 			{
-				Resize(srcLength);
+				Resize(src.Length);
 			}
-			Array.Copy(src, srcOffset, buffer, offset, srcLength);
-			offset += srcLength;
+
+			src.CopyTo(buffer.AsMemory(offset));
+			offset += src.Length;
 		}
 
 		public void PackDouble(double val)

--- a/AerospikeClient/Value/ReadOnlyMemoryBytesValue.cs
+++ b/AerospikeClient/Value/ReadOnlyMemoryBytesValue.cs
@@ -22,7 +22,7 @@ partial class Value
 	/// <summary>
 	/// <see cref="ReadOnlyMemory{T}"/> value.
 	/// </summary>
-	internal sealed class ReadOnlyMemoryBytesValue : Value, IEquatable<ReadOnlyMemoryBytesValue>, IEquatable<ReadOnlyMemory<byte>>
+	public sealed class ReadOnlyMemoryBytesValue : Value, IEquatable<ReadOnlyMemoryBytesValue>, IEquatable<ReadOnlyMemory<byte>>
 	{
 		public ReadOnlyMemory<byte> Bytes { get; }
 

--- a/AerospikeClient/Value/ReadOnlyMemoryBytesValue.cs
+++ b/AerospikeClient/Value/ReadOnlyMemoryBytesValue.cs
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Aerospike.Client;
+
+partial class Value
+{
+	/// <summary>
+	/// <see cref="ReadOnlyMemory{T}"/> value.
+	/// </summary>
+	internal sealed class ReadOnlyMemoryBytesValue : Value, IEquatable<ReadOnlyMemoryBytesValue>, IEquatable<ReadOnlyMemory<byte>>
+	{
+		public ReadOnlyMemory<byte> Bytes { get; }
+
+		public override ParticleType Type => ParticleType.BLOB;
+
+		public override object Object => Bytes;
+
+		public ReadOnlyMemoryBytesValue(ReadOnlyMemory<byte> bytes)
+		{
+			Bytes = bytes;
+		}
+
+		public override int EstimateSize() => Bytes.Length;
+
+		public override int Write(byte[] buffer, int offset)
+		{
+			Bytes.CopyTo(buffer.AsMemory(offset));
+			return Bytes.Length;
+		}
+
+		public override void Pack(Packer packer) => packer.PackParticleBytes(Bytes);
+
+		public override string ToString() => Convert.ToHexString(Bytes.Span);
+
+		public override int GetHashCode()
+		{
+			int result = 1;
+			foreach (byte b in Bytes.Span)
+			{
+				result = 31 * result + b;
+			}
+			return result;
+		}
+
+		public override bool Equals(object obj)
+		{
+			return obj switch
+			{
+				ReadOnlyMemory<byte> mem => Equals(mem),
+				ReadOnlyMemoryBytesValue memValue => Equals(memValue),
+				_ => false
+			};
+		}
+
+		public bool Equals(ReadOnlyMemoryBytesValue other) => other is not null && Equals(other.Bytes);
+
+		public bool Equals(ReadOnlyMemory<byte> other) => Bytes.Span.SequenceEqual(other.Span);
+
+		public static bool operator ==(ReadOnlyMemoryBytesValue o1, ReadOnlyMemoryBytesValue o2) => o1?.Equals(o2) ?? false;
+		public static bool operator !=(ReadOnlyMemoryBytesValue o1, ReadOnlyMemoryBytesValue o2) => !(o1 == o2);
+	}
+}

--- a/AerospikeClient/Value/Value.cs
+++ b/AerospikeClient/Value/Value.cs
@@ -138,6 +138,11 @@ namespace Aerospike.Client
 		static public Value Get(byte[] value, int offset, int length) => value is null ? NullValue.Instance : new ByteSegmentValue(value, offset, length);
 
 		/// <summary>
+		/// Get memory bytes instance.
+		/// </summary>
+		static public Value Get(ReadOnlyMemory<byte> value) => new ReadOnlyMemoryBytesValue(value);
+
+		/// <summary>
 		/// Get double value instance.
 		/// </summary>
 		static public DoubleValue Get(double value) => new(value);
@@ -240,6 +245,8 @@ namespace Aerospike.Client
 			{
 				Value value => value,
 				byte[] bValue => new BytesValue(bValue),
+				Memory<byte> memValue => new ReadOnlyMemoryBytesValue(memValue),
+				ReadOnlyMemory<byte> roMemValue => new ReadOnlyMemoryBytesValue(roMemValue),
 				IList lValue => new ListValue(lValue),
 				IDictionary dValue => new MapValue(dValue),
 				string sValue => new StringValue(sValue),

--- a/AerospikeTest/Sync/Basic/TestOperateList.cs
+++ b/AerospikeTest/Sync/Basic/TestOperateList.cs
@@ -208,6 +208,7 @@ namespace Aerospike.Test
 				Value.Get("string value"),
 				Value.Get(inputList),
 				Value.Get(bytes),
+				Value.Get(bytes.AsMemory()),
 				Value.Get(99.99),
 				Value.Get(inputMap)
 			};
@@ -230,7 +231,7 @@ namespace Aerospike.Test
 			IList list = record.GetList(binName);
 
 			long size = (long)list[0];
-			Assert.AreEqual(7, size);
+			Assert.AreEqual(8, size);
 
 			IList rangeList = (IList)list[1];
 			Assert.IsTrue((bool)rangeList[0]);
@@ -243,12 +244,15 @@ namespace Aerospike.Test
 			Assert.AreEqual(-8734.81, (double)subList[1], 0.00001);
 			Assert.AreEqual("my string", (string)subList[2]);
 
-			byte[] bt = (byte[])rangeList[4];
-			CollectionAssert.AreEqual(bytes, bt, "bytes not equal");
+			byte[] bt1 = (byte[])rangeList[4];
+			CollectionAssert.AreEqual(bytes, bt1, "bytes not equal");
 
-			Assert.AreEqual(99.99, (double)rangeList[5], 0.00001);
+			byte[] bt2 = (byte[])rangeList[5];
+			CollectionAssert.AreEqual(bytes, bt2, "bytes not equal");
 
-			IDictionary subMap = (IDictionary)rangeList[6];
+			Assert.AreEqual(99.99, (double)rangeList[6], 0.00001);
+
+			IDictionary subMap = (IDictionary)rangeList[7];
 			Assert.AreEqual(2, subMap.Count);
 			Assert.AreEqual("data 9", (string)subMap[9L]);
 			Assert.AreEqual("data -2", (string)subMap[-2L]);
@@ -266,7 +270,7 @@ namespace Aerospike.Test
 
 			Assert.AreEqual(1, (long)list[5]);
 			Assert.AreEqual(1, (long)list[6]);
-			Assert.AreEqual(1, (long)list[7]);
+			Assert.AreEqual(2, (long)list[7]);
 
 			size = (long)list[8];
 			Assert.AreEqual(2, size);

--- a/AerospikeTest/Sync/Basic/TestPutGet.cs
+++ b/AerospikeTest/Sync/Basic/TestPutGet.cs
@@ -28,22 +28,57 @@ namespace Aerospike.Test
 			Key key = new(SuiteHelpers.ns, SuiteHelpers.set, "putgetkey");
 			Record record;
 
-			if (SuiteHelpers.singleBin) 
+			if (SuiteHelpers.singleBin)
 			{
 				Bin bin = new("", "value");
-			
+
 				client.Put(null, key, bin);
 				record = client.Get(null, key);
-				AssertBinEqual(key, record, bin);			
+				AssertBinEqual(key, record, bin);
 			}
 			else {
 				Bin bin1 = new("bin1", "value1");
 				Bin bin2 = new("bin2", "value2");
-			
+
 				client.Put(null, key, bin1, bin2);
 				record = client.Get(null, key);
 				AssertBinEqual(key, record, bin1);
-				AssertBinEqual(key, record, bin2);			
+				AssertBinEqual(key, record, bin2);
+			}
+
+			record = client.GetHeader(null, key);
+			AssertRecordFound(key, record);
+
+			// Generation should be greater than zero.  Make sure it's populated.
+			if (record.generation == 0)
+			{
+				Assert.Fail("Invalid record header: generation=" + record.generation + " expiration=" + record.expiration);
+			}
+		}
+
+		[TestMethod]
+		public void PutGetBytes()
+		{
+			Key key = new(SuiteHelpers.ns, SuiteHelpers.set, "putgetbyteskey");
+			Record record;
+
+			if (SuiteHelpers.singleBin)
+			{
+				Bin bin = new("", "value"u8.ToArray().AsMemory());
+
+				client.Put(null, key, bin);
+				record = client.Get(null, key);
+				AssertBinBlobEqual(key, record, bin);
+			}
+			else
+			{
+				Bin bin1 = new("bin1", (Memory<byte>)"value1"u8.ToArray());
+				Bin bin2 = new("bin2", (ReadOnlyMemory<byte>)"value2"u8.ToArray());
+
+				client.Put(null, key, bin1, bin2);
+				record = client.Get(null, key);
+				AssertBinBlobEqual(key, record, bin1);
+				AssertBinBlobEqual(key, record, bin2);
 			}
 
 			record = client.GetHeader(null, key);

--- a/AerospikeTest/Sync/TestSync.cs
+++ b/AerospikeTest/Sync/TestSync.cs
@@ -35,6 +35,26 @@ namespace Aerospike.Test
 			}
 		}
 
+		public static void AssertBinBlobEqual(Key key, Record record, Bin bin)
+		{
+			AssertRecordFound(key, record);
+
+			byte[] received = (byte[])record.GetValue(bin.name);
+
+			byte[] expected = bin.value.Object switch
+			{
+				byte[] bytes => bytes,
+				Memory<byte> mem => mem.ToArray(),
+				ReadOnlyMemory<byte> roMem => roMem.ToArray(),
+				_ => throw new ArgumentException("Unexpected type"),
+			};
+
+			if (received == null || !received.SequenceEqual(expected))
+			{
+				Assert.Fail($"Data mismatch: Expected [{string.Join(", ", expected)}]. Received [{string.Join(", ", received ?? [])}]");
+			}
+		}
+
 		public static void AssertBinEqual(Key key, Record record, String binName, Object expected)
 		{
 			AssertRecordFound(key, record);


### PR DESCRIPTION
[Memory\<byte\>](https://learn.microsoft.com/en-us/dotnet/api/system.memory-1) is the preferred way to work with blobs in .NET. It can represent a slice of an array or any contiguous memory with a custom [MemoryManager\<T\>](https://learn.microsoft.com/en-us/dotnet/api/system.buffers.memorymanager-1). You'll find it in all low-level .NET APIs such as <a href="https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.writeasync?view=net-8.0#system-io-stream-writeasync(system-readonlymemory((system-byte))-system-threading-cancellationtoken)">Stream.WriteAsync</a>, <a href="https://learn.microsoft.com/en-us/dotnet/api/system.net.sockets.socket.sendasync?view=net-8.0#system-net-sockets-socket-sendasync(system-readonlymemory((system-byte))-system-threading-cancellationtoken)">Socket.SendAsync</a>,  or <a href="https://learn.microsoft.com/en-us/dotnet/api/system.buffers.memorypool-1.rent?view=net-8.0#system-buffers-memorypool-1-rent(system-int32)">MemoryPool.Rent</a>.

This change allows creating a `Value` from a `Memory`/`ReadOnlyMemory`. That will enable users some important performance benefits when setting a value. Here is an example where an object with unknown serialized size (`Data`) is serialized to a memory stream.
```csharp
MemoryStream ms = new();
Data.WriteTo(ms);
Value val = Value.Get(ms.ToArray()); // Copy the whole thing :/
```
when with a Memory you could do
```csharp
MemoryStream ms = new();
Data.WriteTo(ms);
ReadOnlyMemory<byte> mem = ms.GetBuffer().AsMemory(0, (int)ms.Length); // No copy
Value val = Value.Get(mem);
```

`Value.Get` actually supports an offset/length for that use-case, but it only solves the problem partially:
- All new .NET bytes APIs use a `Memory<byte>` (e.g. you can't get a `byte[]` from a [ReadOnlySequence](https://learn.microsoft.com/en-us/dotnet/api/system.buffers.readonlysequence-1)). If Aerospike doesn't support this type, the user will have to copy the memory into an array to pass it to the client
- It doesn't support custom [MemoryManager\<T\>](https://learn.microsoft.com/en-us/dotnet/api/system.buffers.memorymanager-1) that only deals with memory