### PR TITLE
Repair release promotion and test workflows

### DIFF
--- a/.github/nightly_test_servers.json
+++ b/.github/nightly_test_servers.json
@@ -16,11 +16,5 @@
     "server-type": "aerospike-server",
     "server-container-repo": "database-docker-virtual/aerospike-server",
     "tls": false
-  },
-  {
-    "server-tag": "latest",
-    "server-type": "aerospike-server",
-    "server-container-repo": "database-docker-virtual/aerospike-server",
-    "tls": true
   }
 ]

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -274,8 +274,13 @@ jobs:
         echo "$records_json" | jq '.'
 
         if echo "$records_json" | jq -e '.errors? | length > 0' >/dev/null; then
-          echo "::error::Failed to fetch promotion records for ${BUNDLE_NAME}/${BUNDLE_VERSION}."
-          exit 1
+          if echo "$records_json" | jq -e '.errors[]? | (.status | tostring) == "404"' >/dev/null; then
+            echo "::warning::Promotion records endpoint returned 404; treating this as no existing promotion records."
+            records_json='{"promotions":[]}'
+          else
+            echo "::error::Failed to fetch promotion records for ${BUNDLE_NAME}/${BUNDLE_VERSION}."
+            exit 1
+          fi
         fi
 
         higher_envs=$(echo "$records_json" | jq -r --arg version "$BUNDLE_VERSION" '

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -250,7 +250,7 @@ jobs:
       run: |
         set -euo pipefail
 
-        records_path="/lifecycle/api/v2/promotion/records/${BUNDLE_NAME}/${BUNDLE_VERSION}?project=${JF_PROJECT}"
+        records_path="/lifecycle/api/v2/promotion/records/${BUNDLE_NAME}?project=${JF_PROJECT}&filter_by=${BUNDLE_VERSION}&order_by=created_millis&order_asc=true"
         echo "Checking promotion records for ${BUNDLE_NAME}/${BUNDLE_VERSION}..."
         records_json='{"promotions":[]}'
         set +e
@@ -273,8 +273,15 @@ jobs:
 
         echo "$records_json" | jq '.'
 
-        higher_envs=$(echo "$records_json" | jq -r '
+        if echo "$records_json" | jq -e '.errors? | length > 0' >/dev/null; then
+          echo "::error::Failed to fetch promotion records for ${BUNDLE_NAME}/${BUNDLE_VERSION}."
+          exit 1
+        fi
+
+        higher_envs=$(echo "$records_json" | jq -r --arg version "$BUNDLE_VERSION" '
           [(.promotions // [])[]?
+            | select((.release_bundle_version // .releaseBundleVersion // .version // "") == $version)
+            | select((.status // "COMPLETED") == "COMPLETED")
             | (.environment // .target_environment // .targetEnvironment // empty)
             | select(. == "STAGE" or . == "PREVIEW" or . == "PROD")]
           | unique
@@ -285,8 +292,10 @@ jobs:
           exit 1
         fi
 
-        existing_envs=$(echo "$records_json" | jq -r '
+        existing_envs=$(echo "$records_json" | jq -r --arg version "$BUNDLE_VERSION" '
           [(.promotions // [])[]?
+            | select((.release_bundle_version // .releaseBundleVersion // .version // "") == $version)
+            | select((.status // "COMPLETED") == "COMPLETED")
             | (.environment // .target_environment // .targetEnvironment // empty)]
           | unique
           | join(", ")

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -1,5 +1,5 @@
 name: Build and test
-run-name: "${{ github.event_name == 'pull_request' && format('PR #{0}', github.event.pull_request.number) || (github.event_name == 'push' && 'Stage') || 'Dev' }} build (${{ inputs.server-tag || 'latest' }}, ${{ contains(inputs.server-type || 'enterprise', 'enterprise') && 'enterprise' || 'community' }}, ${{ format('{0}', inputs.strong-consistency) == 'false' && 'AP' || 'SC' }}${{ inputs.enable-tls && ', TLS' || '' }})"
+run-name: "${{ github.event_name == 'pull_request' && format('PR #{0}', github.event.pull_request.number) || (github.event_name == 'push' && 'Stage') || 'Dev' }} build (${{ inputs.server-tag || 'latest' }}, ${{ (inputs.server-type || 'aerospike-server-enterprise') == 'aerospike-server-enterprise' && 'enterprise' || 'community' }}, ${{ (inputs.server-type || 'aerospike-server-enterprise') == 'aerospike-server-enterprise' && (format('{0}', inputs.strong-consistency) == 'false' && 'AP' || 'SC') || 'AP' }}${{ (inputs.server-type || 'aerospike-server-enterprise') == 'aerospike-server-enterprise' && inputs.enable-tls && ', TLS' || '' }})"
 
 permissions:
   # Required for OIDC token requests (used by JFrog/sign jobs)
@@ -44,12 +44,12 @@ on:
         type: boolean
         required: false
         default: true
-        description: Enable strong consistency
+        description: Enable strong consistency. Enterprise edition required.
       enable-tls:
         type: boolean
         required: false
         default: false
-        description: Enable TLS for server and test connections
+        description: Enable TLS for server and test connections. Enterprise edition required.
 
 jobs:
   build:
@@ -114,6 +114,7 @@ jobs:
     #     avoiding GitHub's loose equality where `null == false` is true.
     #   • For server-type we compare *after* applying the `|| default` fallback
     #     so PR/push runs get the enterprise features.conf, not an empty string.
+    #   • Community server runs are always AP and non-TLS.
     - name: Resolve test inputs
       id: cfg
       shell: bash
@@ -134,6 +135,10 @@ jobs:
           SC="1"
         fi
         if [ "$ENABLE_TLS" = "true" ]; then ENABLE_TLS="true"; else ENABLE_TLS="false"; fi
+        if [ "$SERVER_TYPE" != "aerospike-server-enterprise" ]; then
+          ENABLE_TLS="false"
+          SC="0"
+        fi
         {
           echo "server-tag=$SERVER_TAG"
           echo "server-type=$SERVER_TYPE"

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -23,6 +23,8 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: stage
 
     - name: Load nightly server matrix
       id: servers
@@ -41,6 +43,8 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: stage
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
@@ -70,6 +74,9 @@ jobs:
           - server:
               server-type: aerospike-server
             strong-consistency: "1"
+          - server:
+              server-type: aerospike-server
+              tls: true
     name: test-${{ matrix.server.server-tag }}-${{ matrix.server.server-type }}-sc${{ matrix.strong-consistency }}-tls${{ matrix.server.tls }}
     runs-on: ubuntu-latest
     steps:
@@ -79,6 +86,8 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: stage
     - name: Test
       uses: ./.github/actions/test
       with:
@@ -87,7 +96,7 @@ jobs:
         server-container-repo: ${{ matrix.server.server-container-repo }}
         strong-consistency: ${{ matrix.strong-consistency }}
         enable-tls: ${{ matrix.server.tls }}
-        features-content: ${{ secrets.AES_FEATURES_CONF }}
+        features-content: ${{ matrix.server.server-type == 'aerospike-server-enterprise' && secrets.AES_FEATURES_CONF || '' }}
         oidc-provider: gh-aerospike
         oidc-audience: aerospike
         artifact-suffix: ${{ matrix.server.server-tag }}-${{ matrix.server.server-type }}-sc${{ matrix.strong-consistency }}-tls${{ matrix.server.tls }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -79,6 +79,10 @@ jobs:
         echo "$records_json" | jq '.'
 
         if echo "$records_json" | jq -e '.errors? | length > 0' >/dev/null; then
+          if echo "$records_json" | jq -e '.errors[]? | (.status | tostring) == "404"' >/dev/null; then
+            echo "::warning::Promotion records endpoint returned 404. Skipping local adjacency guard and letting the JFrog promotion action validate ${TARGET_ENV}."
+            exit 0
+          fi
           echo "::error::Failed to fetch promotion records for ${BUNDLE_NAME}/${BUNDLE_VERSION}."
           exit 1
         fi

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -67,21 +67,33 @@ jobs:
           exit 1
         fi
 
-        # Query promotion records for this bundle/version.
-        # Endpoint: GET /lifecycle/api/v2/promotion/records/{name}/{version}?project={project}
-        # Response shape: { "promotions": [ { "environment": "DEV", "created": "...", ... }, ... ] }
+        # Query promotion records for this bundle, then filter to this exact
+        # version. The Lifecycle API does not include the version in the path.
+        # Endpoint: GET /lifecycle/api/v2/promotion/records/{name}?project={project}
+        # Response shape: { "promotions": [ { "release_bundle_version": "...", "environment": "DEV", "status": "COMPLETED", ... }, ... ] }
         echo "Fetching promotion records for ${BUNDLE_NAME}/${BUNDLE_VERSION}..."
         records_json=$(jf rt curl -X GET \
-          "/lifecycle/api/v2/promotion/records/${BUNDLE_NAME}/${BUNDLE_VERSION}?project=${JF_PROJECT}" \
+          "/lifecycle/api/v2/promotion/records/${BUNDLE_NAME}?project=${JF_PROJECT}&filter_by=${BUNDLE_VERSION}&order_by=created_millis&order_asc=true" \
           -H "Accept: application/json")
 
         echo "$records_json" | jq '.'
 
-        # Compute the current stage from the latest promotion record.
+        if echo "$records_json" | jq -e '.errors? | length > 0' >/dev/null; then
+          echo "::error::Failed to fetch promotion records for ${BUNDLE_NAME}/${BUNDLE_VERSION}."
+          exit 1
+        fi
+
+        # Compute the current stage from the latest completed promotion record.
         # -1 means "not yet promoted".
-        current_idx=$(echo "$records_json" | jq --argjson stages '["DEV","TEST","STAGE","PREVIEW","PROD"]' '
+        current_idx=$(echo "$records_json" | jq \
+          --arg version "$BUNDLE_VERSION" \
+          --argjson stages '["DEV","TEST","STAGE","PREVIEW","PROD"]' '
           [(.promotions // [])
-            | sort_by(.created // .createdAt // .created_at // "")
+            | map(select(
+                (.release_bundle_version // .releaseBundleVersion // .version // "") == $version
+                and ((.status // "COMPLETED") == "COMPLETED")
+              ))
+            | sort_by(.created_millis // .createdMillis // .created // .createdAt // .created_at // "")
             | .[]
             | .environment // empty] as $envs
           | ($envs[-1] // null) as $current

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -98,9 +98,18 @@ jobs:
 
     - name: List downloaded packages
       run: |
+        set -euo pipefail
+
         echo "Downloaded packages:"
-        ls -la packages/
-        for pkg in packages/*.nupkg; do
+        find packages/ -type f | sort
+
+        mapfile -t packages_to_publish < <(find packages/ -type f -name "*.nupkg" | sort)
+        if [ "${#packages_to_publish[@]}" -eq 0 ]; then
+          echo "::error::No .nupkg files found in downloaded artifact from run ${{ inputs.run-id }}."
+          exit 1
+        fi
+
+        for pkg in "${packages_to_publish[@]}"; do
           echo "=== $(basename "$pkg") ==="
           unzip -l "$pkg" | tail -5
         done
@@ -108,13 +117,25 @@ jobs:
     - name: Push to NuGet.org
       if: ${{ !inputs.dry-run }}
       run: |
-        dotnet nuget push "packages/*.nupkg" \
-          --api-key "${{ secrets.NUGET_API_KEY }}" \
-          --source https://api.nuget.org/v3/index.json \
-          --skip-duplicate
+        set -euo pipefail
+
+        mapfile -t packages_to_publish < <(find packages/ -type f -name "*.nupkg" | sort)
+        if [ "${#packages_to_publish[@]}" -eq 0 ]; then
+          echo "::error::No .nupkg files found in downloaded artifact from run ${{ inputs.run-id }}."
+          exit 1
+        fi
+
+        for pkg in "${packages_to_publish[@]}"; do
+          dotnet nuget push "$pkg" \
+            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+        done
 
     - name: Summary
       run: |
+        set -euo pipefail
+
         if [ "${{ inputs.dry-run }}" = "true" ]; then
           echo "::notice::DRY RUN — No packages were published to NuGet.org"
           echo "## Dry Run Summary" >> $GITHUB_STEP_SUMMARY
@@ -125,9 +146,9 @@ jobs:
         echo "**Source run ID:** \`${{ inputs.run-id }}\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Packages" >> $GITHUB_STEP_SUMMARY
-        for pkg in packages/*.nupkg; do
+        while IFS= read -r pkg; do
           echo "- \`$(basename "$pkg")\`" >> $GITHUB_STEP_SUMMARY
-        done
+        done < <(find packages/ -type f -name "*.nupkg" | sort)
         if [ "${{ inputs.dry-run }}" = "true" ]; then
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "To publish for real, re-run this workflow with **dry-run** unchecked." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       id: get-version
       shell: pwsh
       run: |
-        $projectXml = git show "${{ steps.target.outputs.sha }}:AerospikeClient/AerospikeClient.csproj"
+        $projectXml = (git show "${{ steps.target.outputs.sha }}:AerospikeClient/AerospikeClient.csproj") -join "`n"
         [xml]$project = $projectXml
         $version = $project.Project.PropertyGroup.Version | Select-Object -First 1
         if (-not $version) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,8 @@ jobs:
       shell: pwsh
       run: |
         $projectXml = (git show "${{ steps.target.outputs.sha }}:AerospikeClient/AerospikeClient.csproj") -join "`n"
-        [xml]$project = $projectXml
-        $version = $project.Project.PropertyGroup.Version | Select-Object -First 1
+        $versionMatch = [regex]::Match($projectXml, '<Version>\s*([^<]+?)\s*</Version>')
+        $version = $versionMatch.Groups[1].Value
         if (-not $version) {
           Write-Error "Could not read <Version> from AerospikeClient/AerospikeClient.csproj at ${{ steps.target.outputs.sha }}"
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   resolve-release:
@@ -33,7 +34,7 @@ jobs:
       shell: bash
       run: |
         set -euo pipefail
-        git fetch --no-tags --depth=0 origin stage
+        git fetch --no-tags origin stage:refs/remotes/origin/stage
         target=$(git merge-base HEAD origin/stage)
         echo "Release target SHA: $target"
         echo "sha=$target" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fix release and promotion workflow handling for JFrog lifecycle promotion records and release target resolution.
- Keep stage/nightly validation aligned with the `stage` branch and avoid invalid community server TLS/SC test combinations.
- Harden break-glass NuGet publishing so package discovery and publishing handle downloaded artifacts reliably.

## Changes
- Release workflows
  - Query JFrog promotion records using the bundle name endpoint and filter by bundle version/status.
  - Treat promotion-record 404 responses as no existing records where appropriate.
  - Prevent release bundle replacement when completed higher-environment promotions already exist.
  - Fix release target fetching and version parsing for release tagging/API docs.
  - Add manual dispatch support for the release workflow.
- Test workflows
  - Run nightly checkout/build/test steps from `stage`.
  - Exclude unsupported community TLS/SC combinations and only pass enterprise features for enterprise server tests.
  - Clarify that TLS and strong consistency dispatch inputs require Enterprise.
- Publishing workflow
  - Discover downloaded `.nupkg` files with `find`, fail when none are present, and publish each package explicitly.
  - Make dry-run and publish summaries reflect the actual discovered package files.

## Test plan
- Not run locally; changes are GitHub Actions workflow updates.
- Verify by running PR checks against `stage`.
- Optionally run `Nightly Extended Tests`, `Release`, `Promote release bundle`, and `Publish NuGet` manually in dry-run or non-production paths as applicable.

## Changes Breakdown

| Category | +add | -del | net | files |
| --- | ---: | ---: | ---: | ---: |
| YAML (workflows) | 92 | 26 | +66 | 5 |
| JSON (config) | 0 | 6 | -6 | 1 |
| **Total** | **92** | **32** | **+60** | **6** |

Most churn is in GitHub Actions workflow YAML, especially release/promote lifecycle handling and package publishing robustness.