### PR TITLE
Add logic for dependabot or fork PRs to proceed with checks without secrets

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -3,7 +3,12 @@ description: Builds signed nuget package
 
 inputs:
   sgKey:
-    required: true
+    required: false
+    default: ""
+  sign-client:
+    required: false
+    default: "true"
+    description: Re-sign AerospikeClient.dll with the private strong-name key.
 
 runs:
   using: composite
@@ -17,13 +22,18 @@ runs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Create Code Signing Key
+      if: inputs.sign-client == 'true'
       shell: pwsh
       run: |
+        if ([string]::IsNullOrWhiteSpace('${{ inputs.sgKey }}')) {
+          throw "sgKey is required when sign-client is true."
+        }
         New-Item -ItemType directory -Path key
         Set-Content -Path key\key.txt -Value '${{ inputs.sgKey }}'
         certutil -decode key\key.txt key\key.snk
 
     - name: Delay Sign dll
+      if: inputs.sign-client == 'true'
       shell: pwsh
       run: |
         & 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8.1 Tools\sn.exe' -R .\AerospikeClient\bin\Release\net8.0\AerospikeClient.dll key\key.snk

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -13,7 +13,7 @@ permissions:
 # post-merge build that publishes RC artifacts to JFrog.
 #
 # Trigger matrix:
-#   pull_request      → PR validation (build/sign/test, deploy to JFrog)
+#   pull_request      → PR validation (build/test; signing only for trusted PRs)
 #   push to stage     → post-merge build (build/sign/test, deploy to JFrog,
 #                       create release bundle, promote to TEST)
 #   workflow_dispatch → ad-hoc dev build with custom server settings
@@ -72,6 +72,7 @@ jobs:
       uses: ./.github/actions/build
       with:
         sgKey: ${{ secrets.SG_KEY }}
+        sign-client: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
     - name: Get version from nupkg
       id: get-version
@@ -82,6 +83,7 @@ jobs:
         echo "version=$version" >> $env:GITHUB_OUTPUT
 
   sign:
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     needs: build
     uses: aerospike/shared-workflows/.github/workflows/reusable_sign-artifacts.yaml@8ec712eafbec26c8db8d1183688a5fd806560a95 # v3.5.0
     with:
@@ -107,13 +109,13 @@ jobs:
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    # Resolve test inputs once so PR/push runs (which have no `inputs.*`)
+    # Resolve test inputs once so trusted PR/push runs (which have no `inputs.*`)
     # behave the same as a workflow_dispatch run that accepts all defaults.
     # Notes on the tricky cases:
     #   • `format('{0}', inputs.X)` coerces null → '' for safe string compare,
     #     avoiding GitHub's loose equality where `null == false` is true.
-    #   • For server-type we compare *after* applying the `|| default` fallback
-    #     so PR/push runs get the enterprise features.conf, not an empty string.
+    #   • Untrusted PRs (Dependabot/forks) use the community server so they do
+    #     not need private signing or enterprise features.conf secrets.
     #   • Community server runs are always AP and non-TLS.
     - name: Resolve test inputs
       id: cfg
@@ -123,9 +125,14 @@ jobs:
         IN_SERVER_TYPE: ${{ inputs.server-type }}
         IN_ENABLE_TLS: ${{ format('{0}', inputs.enable-tls) }}
         IN_STRONG_CONSISTENCY: ${{ format('{0}', inputs.strong-consistency) }}
+        IN_TRUSTED_SECRETS: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
       run: |
         SERVER_TAG="${IN_SERVER_TAG:-latest}"
-        SERVER_TYPE="${IN_SERVER_TYPE:-aerospike-server-enterprise}"
+        if [ "$IN_TRUSTED_SECRETS" = "true" ]; then
+          SERVER_TYPE="${IN_SERVER_TYPE:-aerospike-server-enterprise}"
+        else
+          SERVER_TYPE="${IN_SERVER_TYPE:-aerospike-server}"
+        fi
         ENABLE_TLS="${IN_ENABLE_TLS:-false}"
         # Default SC to '1' (enabled). Only flip to '0' when the dispatch input
         # is explicitly false; null/empty (PR/push) keeps the default.
@@ -154,22 +161,22 @@ jobs:
         server-type: ${{ steps.cfg.outputs.server-type }}
         enable-tls: ${{ steps.cfg.outputs.enable-tls }}
         strong-consistency: ${{ steps.cfg.outputs.strong-consistency }}
-        features-content: ${{ steps.cfg.outputs.is-enterprise == 'true' && secrets.AES_FEATURES_CONF || '' }}
+        features-content: ${{ steps.cfg.outputs.is-enterprise == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')) && secrets.AES_FEATURES_CONF || '' }}
         oidc-provider: gh-aerospike
         oidc-audience: aerospike
 
-    # PR-only: surface test results as a check + comment on the pull request.
-    # On `push` and `workflow_dispatch` runs there's no PR to attach to.
+    # Trusted PR-only: surface test results as a check + comment on the pull request.
+    # Dependabot/fork PR tokens cannot write checks/comments.
     - name: Publish test results
-      if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+      if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
       uses: step-security/publish-unit-test-result-action@681100d67b09305624c089873f12c545ee7cbc24 # v2.23.0
       with:
         files: test-results/**/*.trx
         check_name: "Test Results (${{ steps.cfg.outputs.server-tag }})"
 
-    # PR-only: publish example smoke tests as their own result check.
+    # Trusted PR-only: publish example smoke tests as their own result check.
     - name: Publish example run results
-      if: ${{ !cancelled() && github.event_name == 'pull_request' && hashFiles('example-results/**/*.trx') != '' }}
+      if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && hashFiles('example-results/**/*.trx') != '' }}
       uses: step-security/publish-unit-test-result-action@681100d67b09305624c089873f12c545ee7cbc24 # v2.23.0
       with:
         files: example-results/**/*.trx

--- a/AerospikeAdmin/AerospikeAdmin.csproj
+++ b/AerospikeAdmin/AerospikeAdmin.csproj
@@ -22,7 +22,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <Version>8.5.0</Version>
+    <Version>8.4.2</Version>
     <Configurations>Debug;Release;Release_Unix;Debug_Unix</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>

--- a/AerospikeBenchmarks/AerospikeBenchmarks.csproj
+++ b/AerospikeBenchmarks/AerospikeBenchmarks.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
-    <Version>8.5.0</Version>
+    <Version>8.4.2</Version>
     <Configurations>Debug;Release;Debug_Unix;Release_Unix</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>

--- a/AerospikeClient/AerospikeClient.csproj
+++ b/AerospikeClient/AerospikeClient.csproj
@@ -19,7 +19,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Icon>icon.png</Icon>
     <Copyright>Copyright 2012-2026 Aerospike, Inc.</Copyright>
-    <Version>8.5.0</Version>
+    <Version>8.4.2</Version>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />

--- a/AerospikeExample/AerospikeExample.csproj
+++ b/AerospikeExample/AerospikeExample.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Aerospike.Example</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <Version>8.5.0</Version>
+    <Version>8.4.2</Version>
     <Configurations>Debug;Release;Debug_Unix;Release_Unix</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>

--- a/AerospikeTest/AerospikeTest.csproj
+++ b/AerospikeTest/AerospikeTest.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>AerospikeTest</AssemblyName>
     <TestingExtensionsProfile>Default</TestingExtensionsProfile>
     <IsPackable>false</IsPackable>
-    <Version>8.5.0</Version>
+    <Version>8.4.2</Version>
     <Company>Aerospike</Company>
     <Authors>Aerospike</Authors>
     <Platforms>AnyCPU</Platforms>


### PR DESCRIPTION
## Summary
- Let PR validation run without private repo secrets for Dependabot and forked community PRs.
- Add an explicit `sign-client` switch to the build action so trusted runs still strong-name sign packages, while untrusted PRs skip the private signing key path.
- Default untrusted PR tests to the community/AP server and skip PR result publishing that requires write permissions.

## Why
Dependabot-triggered `pull_request` runs do not receive normal GitHub Actions secrets, so `secrets.SG_KEY` resolves empty and `sn.exe` fails while re-signing `AerospikeClient.dll`. Forked community PRs have the same secret/write-token restriction. This keeps validation useful without exposing private signing or enterprise feature secrets.

## Behavior
- Trusted internal PRs, `push` to `stage`, and manual workflow runs keep the existing signed build and enterprise test path.
- Dependabot and fork PRs build/package without private strong-name signing, test against the community AP server, and skip check/comment publishing steps that need write permissions.

## Test plan
- `git diff --check`
- Verified the failing Dependabot run failed after build success because `SG_KEY` was empty and `sn.exe` received a 0-byte key.
- `actionlint` was not installed locally; GitHub Actions syntax will be validated by CI.